### PR TITLE
Make retryTimeout exported variable.

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -7,13 +7,13 @@ import (
 	"github.com/cenkalti/backoff"
 )
 
-const retryTimeout = 1 * time.Minute // TODO: make this configurable
+var RetryTimeout = 1 * time.Minute
 
 func retry(f func() error) error {
 	var err error
 	var next time.Duration
 	b := backoff.NewExponentialBackOff()
-	b.MaxElapsedTime = retryTimeout
+	b.MaxElapsedTime = RetryTimeout
 
 	for {
 		if err = f(); err == nil {


### PR DESCRIPTION
Hi, thanks for this library, @guregu .

I am troubled about which retryTimeout cannot be configured.
You seems to plan to fix this issue(https://github.com/guregu/dynamo/issues/14), but this value should be exported variable until that time.