### PR TITLE
Add context support

### DIFF
--- a/batchget.go
+++ b/batchget.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/cenkalti/backoff"
 )
@@ -168,6 +169,10 @@ func newBGIter(bg *BatchGet, fn unmarshalFunc, err error) *bgIter {
 // Next tries to unmarshal the next result into out.
 // Returns false when it is complete or if it runs into an error.
 func (itr *bgIter) Next(out interface{}) bool {
+	return itr.NextWithContext(aws.BackgroundContext(), out)
+}
+
+func (itr *bgIter) NextWithContext(ctx aws.Context, out interface{}) bool {
 	// stop if we have an error
 	if itr.err != nil {
 		return false
@@ -209,7 +214,7 @@ func (itr *bgIter) Next(out interface{}) bool {
 
 	itr.err = retry(func() error {
 		var err error
-		itr.output, err = itr.bg.batch.table.db.client.BatchGetItem(itr.input)
+		itr.output, err = itr.bg.batch.table.db.client.BatchGetItemWithContext(ctx, itr.input)
 		return err
 	})
 

--- a/createtable.go
+++ b/createtable.go
@@ -132,7 +132,9 @@ func (ct *CreateTable) Project(index string, projection IndexProjection, include
 
 // Run creates this table or returns and error.
 func (ct *CreateTable) Run() error {
-	return ct.RunWithContext(aws.BackgroundContext())
+	ctx, cancel := defaultContext()
+	defer cancel()
+	return ct.RunWithContext(ctx)
 }
 
 func (ct *CreateTable) RunWithContext(ctx aws.Context) error {
@@ -141,7 +143,7 @@ func (ct *CreateTable) RunWithContext(ctx aws.Context) error {
 	}
 
 	input := ct.input()
-	return retry(func() error {
+	return retry(ctx, func() error {
 		_, err := ct.db.client.CreateTableWithContext(ctx, input)
 		return err
 	})

--- a/createtable.go
+++ b/createtable.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
@@ -131,13 +132,17 @@ func (ct *CreateTable) Project(index string, projection IndexProjection, include
 
 // Run creates this table or returns and error.
 func (ct *CreateTable) Run() error {
+	return ct.RunWithContext(aws.BackgroundContext())
+}
+
+func (ct *CreateTable) RunWithContext(ctx aws.Context) error {
 	if ct.err != nil {
 		return ct.err
 	}
 
 	input := ct.input()
 	return retry(func() error {
-		_, err := ct.db.client.CreateTable(input)
+		_, err := ct.db.client.CreateTableWithContext(ctx, input)
 		return err
 	})
 	return nil

--- a/decode_test.go
+++ b/decode_test.go
@@ -19,7 +19,7 @@ func TestUnmarshalAppend(t *testing.T) {
 	item := map[string]*dynamodb.AttributeValue{
 		"UserID": &dynamodb.AttributeValue{N: &id},
 		"Page":   &dynamodb.AttributeValue{N: &page},
-		"Limit":   &dynamodb.AttributeValue{N: &limit},
+		"Limit":  &dynamodb.AttributeValue{N: &limit},
 	}
 
 	for range [15]struct{}{} {

--- a/delete.go
+++ b/delete.go
@@ -59,7 +59,9 @@ func (d *Delete) If(expr string, args ...interface{}) *Delete {
 
 // Run executes this delete request.
 func (d *Delete) Run() error {
-	return d.RunWithContext(aws.BackgroundContext())
+	ctx, cancel := defaultContext()
+	defer cancel()
+	return d.RunWithContext(ctx)
 }
 
 func (d *Delete) RunWithContext(ctx aws.Context) error {
@@ -71,7 +73,9 @@ func (d *Delete) RunWithContext(ctx aws.Context) error {
 // OldValue executes this delete request, unmarshaling the previous value to out.
 // Returns ErrNotFound is there was no previous value.
 func (d *Delete) OldValue(out interface{}) error {
-	return d.OldValueWithContext(aws.BackgroundContext(), out)
+	ctx, cancel := defaultContext()
+	defer cancel()
+	return d.OldValueWithContext(ctx, out)
 }
 
 func (d *Delete) OldValueWithContext(ctx aws.Context, out interface{}) error {
@@ -93,7 +97,7 @@ func (d *Delete) run(ctx aws.Context) (*dynamodb.DeleteItemOutput, error) {
 
 	input := d.deleteInput()
 	var output *dynamodb.DeleteItemOutput
-	err := retry(func() error {
+	err := retry(ctx, func() error {
 		var err error
 		output, err = d.table.db.client.DeleteItemWithContext(ctx, input)
 		return err

--- a/query.go
+++ b/query.go
@@ -229,6 +229,10 @@ func (q *Query) OneWithContext(ctx aws.Context, out interface{}) error {
 
 // Count executes this request, returning the number of results.
 func (q *Query) Count() (int64, error) {
+	return q.CountWithContext(aws.BackgroundContext())
+}
+
+func (q *Query) CountWithContext(ctx aws.Context) (int64, error) {
 	if q.err != nil {
 		return 0, q.err
 	}
@@ -241,7 +245,7 @@ func (q *Query) Count() (int64, error) {
 
 		err := retry(func() error {
 			var err error
-			res, err = q.table.db.client.Query(req)
+			res, err = q.table.db.client.QueryWithContext(ctx, req)
 			if err != nil {
 				return err
 			}
@@ -279,6 +283,10 @@ type queryIter struct {
 // Next tries to unmarshal the next result into out.
 // Returns false when it is complete or if it runs into an error.
 func (itr *queryIter) Next(out interface{}) bool {
+	return itr.NextWithContext(aws.BackgroundContext(), out)
+}
+
+func (itr *queryIter) NextWithContext(ctx aws.Context, out interface{}) bool {
 	// stop if we have an error
 	if itr.err != nil {
 		return false
@@ -315,7 +323,7 @@ func (itr *queryIter) Next(out interface{}) bool {
 
 	itr.err = retry(func() error {
 		var err error
-		itr.output, err = itr.query.table.db.client.Query(itr.input)
+		itr.output, err = itr.query.table.db.client.QueryWithContext(ctx, itr.input)
 		return err
 	})
 

--- a/query.go
+++ b/query.go
@@ -167,6 +167,10 @@ func (q *Query) Order(order Order) *Query {
 // One executes this query and retrieves a single result,
 // unmarshaling the result to out.
 func (q *Query) One(out interface{}) error {
+	return q.OneWithContext(aws.BackgroundContext(), out)
+}
+
+func (q *Query) OneWithContext(ctx aws.Context, out interface{}) error {
 	if q.err != nil {
 		return q.err
 	}
@@ -178,7 +182,7 @@ func (q *Query) One(out interface{}) error {
 		var res *dynamodb.GetItemOutput
 		err := retry(func() error {
 			var err error
-			res, err = q.table.db.client.GetItem(req)
+			res, err = q.table.db.client.GetItemWithContext(ctx, req)
 			if err != nil {
 				return err
 			}
@@ -200,7 +204,7 @@ func (q *Query) One(out interface{}) error {
 	var res *dynamodb.QueryOutput
 	err := retry(func() error {
 		var err error
-		res, err = q.table.db.client.Query(req)
+		res, err = q.table.db.client.QueryWithContext(ctx, req)
 		if err != nil {
 			return err
 		}

--- a/retry.go
+++ b/retry.go
@@ -12,6 +12,7 @@ import (
 // RetryTimeout defines the maximum amount of time that requests will
 // attempt to automatically retry for. In other words, this is the maximum
 // amount of time that dynamo operations will block.
+// RetryTimeout is only considered by methods that do not take a context.
 // Higher values are better when using tables with lower throughput.
 var RetryTimeout = 1 * time.Minute
 

--- a/scan.go
+++ b/scan.go
@@ -3,6 +3,7 @@ package dynamo
 import (
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
@@ -128,6 +129,10 @@ type scanIter struct {
 // Next tries to unmarshal the next result into out.
 // Returns false when it is complete or if it runs into an error.
 func (itr *scanIter) Next(out interface{}) bool {
+	return itr.NextWithContext(aws.BackgroundContext(), out)
+}
+
+func (itr *scanIter) NextWithContext(ctx aws.Context, out interface{}) bool {
 	// stop if we have an error
 	if itr.err != nil {
 		return false
@@ -158,7 +163,7 @@ func (itr *scanIter) Next(out interface{}) bool {
 
 	itr.err = retry(func() error {
 		var err error
-		itr.output, err = itr.scan.table.db.client.Scan(itr.input)
+		itr.output, err = itr.scan.table.db.client.ScanWithContext(ctx, itr.input)
 		return err
 	})
 

--- a/scan.go
+++ b/scan.go
@@ -129,7 +129,9 @@ type scanIter struct {
 // Next tries to unmarshal the next result into out.
 // Returns false when it is complete or if it runs into an error.
 func (itr *scanIter) Next(out interface{}) bool {
-	return itr.NextWithContext(aws.BackgroundContext(), out)
+	ctx, cancel := defaultContext()
+	defer cancel()
+	return itr.NextWithContext(ctx, out)
 }
 
 func (itr *scanIter) NextWithContext(ctx aws.Context, out interface{}) bool {
@@ -161,7 +163,7 @@ func (itr *scanIter) NextWithContext(ctx aws.Context, out interface{}) bool {
 		itr.idx = 0
 	}
 
-	itr.err = retry(func() error {
+	itr.err = retry(ctx, func() error {
 		var err error
 		itr.output, err = itr.scan.table.db.client.ScanWithContext(ctx, itr.input)
 		return err

--- a/substitute.go
+++ b/substitute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 
-	"github.com/guregu/dynamo/internal/exprs"
+	"github.com/qzaidi/dynamo/internal/exprs"
 )
 
 // subber is a "mixin" for operators for keep track of subtituted keys and values

--- a/substitute.go
+++ b/substitute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 
-	"github.com/qzaidi/dynamo/internal/exprs"
+	"github.com/guregu/dynamo/internal/exprs"
 )
 
 // subber is a "mixin" for operators for keep track of subtituted keys and values

--- a/table.go
+++ b/table.go
@@ -37,12 +37,14 @@ func (table Table) DeleteTable() *DeleteTable {
 
 // Run executes this request and deletes the table.
 func (dt *DeleteTable) Run() error {
-	return dt.RunWithContext(aws.BackgroundContext())
+	ctx, cancel := defaultContext()
+	defer cancel()
+	return dt.RunWithContext(ctx)
 }
 
 func (dt *DeleteTable) RunWithContext(ctx aws.Context) error {
 	input := dt.input()
-	return retry(func() error {
+	return retry(ctx, func() error {
 		_, err := dt.table.db.client.DeleteTableWithContext(ctx, input)
 		return err
 	})

--- a/table.go
+++ b/table.go
@@ -1,6 +1,7 @@
 package dynamo
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
@@ -36,9 +37,13 @@ func (table Table) DeleteTable() *DeleteTable {
 
 // Run executes this request and deletes the table.
 func (dt *DeleteTable) Run() error {
+	return dt.RunWithContext(aws.BackgroundContext())
+}
+
+func (dt *DeleteTable) RunWithContext(ctx aws.Context) error {
 	input := dt.input()
 	return retry(func() error {
-		_, err := dt.table.db.client.DeleteTable(input)
+		_, err := dt.table.db.client.DeleteTableWithContext(ctx, input)
 		return err
 	})
 }

--- a/update.go
+++ b/update.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
@@ -173,15 +174,23 @@ func (u *Update) If(expr string, args ...interface{}) *Update {
 
 // Run executes this update.
 func (u *Update) Run() error {
+	return u.RunWithContext(aws.BackgroundContext())
+}
+
+func (u *Update) RunWithContext(ctx aws.Context) error {
 	u.returnType = "NONE"
-	_, err := u.run()
+	_, err := u.run(ctx)
 	return err
 }
 
 // Value executes this update, encoding out with the new value.
 func (u *Update) Value(out interface{}) error {
+	return u.ValueWithContext(aws.BackgroundContext(), out)
+}
+
+func (u *Update) ValueWithContext(ctx aws.Context, out interface{}) error {
 	u.returnType = "ALL_NEW"
-	output, err := u.run()
+	output, err := u.run(ctx)
 	if err != nil {
 		return err
 	}
@@ -190,15 +199,18 @@ func (u *Update) Value(out interface{}) error {
 
 // OldValue executes this update, encoding out with the previous value.
 func (u *Update) OldValue(out interface{}) error {
+	return u.OldValueWithContext(aws.BackgroundContext(), out)
+}
+func (u *Update) OldValueWithContext(ctx aws.Context, out interface{}) error {
 	u.returnType = "ALL_OLD"
-	output, err := u.run()
+	output, err := u.run(ctx)
 	if err != nil {
 		return err
 	}
 	return unmarshalItem(output.Attributes, out)
 }
 
-func (u *Update) run() (*dynamodb.UpdateItemOutput, error) {
+func (u *Update) run(ctx aws.Context) (*dynamodb.UpdateItemOutput, error) {
 	if u.err != nil {
 		return nil, u.err
 	}
@@ -207,7 +219,7 @@ func (u *Update) run() (*dynamodb.UpdateItemOutput, error) {
 	var output *dynamodb.UpdateItemOutput
 	err := retry(func() error {
 		var err error
-		output, err = u.table.db.client.UpdateItem(input)
+		output, err = u.table.db.client.UpdateItemWithContext(ctx, input)
 		return err
 	})
 	return output, err

--- a/update.go
+++ b/update.go
@@ -174,7 +174,9 @@ func (u *Update) If(expr string, args ...interface{}) *Update {
 
 // Run executes this update.
 func (u *Update) Run() error {
-	return u.RunWithContext(aws.BackgroundContext())
+	ctx, cancel := defaultContext()
+	defer cancel()
+	return u.RunWithContext(ctx)
 }
 
 func (u *Update) RunWithContext(ctx aws.Context) error {
@@ -185,7 +187,9 @@ func (u *Update) RunWithContext(ctx aws.Context) error {
 
 // Value executes this update, encoding out with the new value.
 func (u *Update) Value(out interface{}) error {
-	return u.ValueWithContext(aws.BackgroundContext(), out)
+	ctx, cancel := defaultContext()
+	defer cancel()
+	return u.ValueWithContext(ctx, out)
 }
 
 func (u *Update) ValueWithContext(ctx aws.Context, out interface{}) error {
@@ -199,7 +203,9 @@ func (u *Update) ValueWithContext(ctx aws.Context, out interface{}) error {
 
 // OldValue executes this update, encoding out with the previous value.
 func (u *Update) OldValue(out interface{}) error {
-	return u.OldValueWithContext(aws.BackgroundContext(), out)
+	ctx, cancel := defaultContext()
+	defer cancel()
+	return u.OldValueWithContext(ctx, out)
 }
 func (u *Update) OldValueWithContext(ctx aws.Context, out interface{}) error {
 	u.returnType = "ALL_OLD"
@@ -217,7 +223,7 @@ func (u *Update) run(ctx aws.Context) (*dynamodb.UpdateItemOutput, error) {
 
 	input := u.updateInput()
 	var output *dynamodb.UpdateItemOutput
-	err := retry(func() error {
+	err := retry(ctx, func() error {
 		var err error
 		output, err = u.table.db.client.UpdateItemWithContext(ctx, input)
 		return err


### PR DESCRIPTION
This is #31 with some extra context support for retrying, etc. 
This should have backwards compatibility in that the old methods that don't take context will still respect `dynamo.RetryTimeout`. 