### PR TITLE
Better compatibility with the official AWS package

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 )
 
 // Unmarshaler is the interface implemented by objects that can unmarshal
@@ -47,6 +48,8 @@ func unmarshalReflect(av *dynamodb.AttributeValue, rv reflect.Value) error {
 			return nil
 		case Unmarshaler:
 			return x.UnmarshalDynamo(av)
+		case dynamodbattribute.Unmarshaler:
+			return x.UnmarshalDynamoDBAttributeValue(av)
 		case encoding.TextUnmarshaler:
 			if av.S != nil {
 				return x.UnmarshalText([]byte(*av.S))

--- a/decode.go
+++ b/decode.go
@@ -41,12 +41,15 @@ func unmarshalReflect(av *dynamodb.AttributeValue, rv reflect.Value) error {
 			iface = rv.Interface()
 		}
 
-		if u, ok := iface.(Unmarshaler); ok {
-			return u.UnmarshalDynamo(av)
-		}
-		if u, ok := iface.(encoding.TextUnmarshaler); ok {
+		switch x := iface.(type) {
+		case *dynamodb.AttributeValue:
+			*x = *av
+			return nil
+		case Unmarshaler:
+			return x.UnmarshalDynamo(av)
+		case encoding.TextUnmarshaler:
 			if av.S != nil {
-				return u.UnmarshalText([]byte(*av.S))
+				return x.UnmarshalText([]byte(*av.S))
 			}
 		}
 	}
@@ -257,6 +260,11 @@ func fieldsInStruct(rv reflect.Value) map[string]reflect.Value {
 
 // unmarshals a struct
 func unmarshalItem(item map[string]*dynamodb.AttributeValue, out interface{}) error {
+	if out, ok := out.(*map[string]*dynamodb.AttributeValue); ok {
+		*out = item
+		return nil
+	}
+
 	rv := reflect.ValueOf(out)
 	if rv.Kind() != reflect.Ptr {
 		return fmt.Errorf("dynamo: unmarshal: not a pointer: %T", out)

--- a/encode.go
+++ b/encode.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 )
 
 // Marshaler is the interface implemented by objects that can marshal themselves into
@@ -104,6 +105,9 @@ func marshal(v interface{}, special string) (*dynamodb.AttributeValue, error) {
 		return x, nil
 	case Marshaler:
 		return x.MarshalDynamo()
+	case dynamodbattribute.Marshaler:
+		av := &dynamodb.AttributeValue{}
+		return av, x.MarshalDynamoDBAttributeValue(av)
 	case encoding.TextMarshaler:
 		text, err := x.MarshalText()
 		if err != nil {

--- a/encode.go
+++ b/encode.go
@@ -100,6 +100,8 @@ func Marshal(v interface{}) (*dynamodb.AttributeValue, error) {
 
 func marshal(v interface{}, special string) (*dynamodb.AttributeValue, error) {
 	switch x := v.(type) {
+	case *dynamodb.AttributeValue:
+		return x, nil
 	case Marshaler:
 		return x.MarshalDynamo()
 	case encoding.TextMarshaler:

--- a/encoding_aws.go
+++ b/encoding_aws.go
@@ -1,0 +1,30 @@
+package dynamo
+
+import (
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+)
+
+type Coder interface {
+	Marshaler
+	Unmarshaler
+}
+
+type awsEncoder struct {
+	iface interface{}
+}
+
+func (w awsEncoder) MarshalDynamo() (*dynamodb.AttributeValue, error) {
+	return dynamodbattribute.Marshal(w.iface)
+}
+
+func (w awsEncoder) UnmarshalDynamo(av *dynamodb.AttributeValue) error {
+	return dynamodbattribute.Unmarshal(av, w.iface)
+}
+
+// AWSEncoding wraps an object, forcing it to use AWS's official dynamodbattribute package
+// for encoding and decoding. This allows you to use the "dynamodbav" struct tags.
+// When decoding, v must be a pointer.
+func AWSEncoding(v interface{}) Coder {
+	return awsEncoder{v}
+}

--- a/encoding_aws_test.go
+++ b/encoding_aws_test.go
@@ -21,7 +21,7 @@ type awsTestWidget struct {
 func TestAWSEncoding(t *testing.T) {
 	w := awsTestWidget{
 		UserID:    555,
-		Time:      time.Now(),
+		Time:      time.Now().UTC(),
 		Msg:       "hello",
 		Count:     0,
 		Friends:   []string{"a", "b"},

--- a/encoding_aws_test.go
+++ b/encoding_aws_test.go
@@ -1,0 +1,82 @@
+package dynamo
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+)
+
+type awsTestWidget struct {
+	UserID int       // Hash key, a.k.a. partition key
+	Time   time.Time // Range key, a.k.a. sort key
+
+	Msg       string   `dynamodbav:"Message"`
+	Count     int      `dynamodbav:",omitempty"`
+	Friends   []string `dynamodbav:",stringset"` // Sets
+	SecretKey string   `dynamodbav:"-"`          // Ignored
+}
+
+func TestAWSEncoding(t *testing.T) {
+	w := awsTestWidget{
+		UserID:    555,
+		Time:      time.Now(),
+		Msg:       "hello",
+		Count:     0,
+		Friends:   []string{"a", "b"},
+		SecretKey: "seeeekret",
+	}
+	av, err := Marshal(AWSEncoding(w))
+	if err != nil {
+		t.Error(err)
+	}
+	official, err := dynamodbattribute.Marshal(w)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(av, official) {
+		t.Error("AWS marshal not equal")
+	}
+
+	blank := awsTestWidget{}
+	err = Unmarshal(official, AWSEncoding(&blank))
+	if err != nil {
+		t.Error(err)
+	}
+	w.SecretKey = ""
+
+	if !reflect.DeepEqual(w, blank) {
+		t.Error("AWS unmarshal not equal")
+		t.Logf("%#v != %#v", w, blank)
+	}
+}
+
+func TestAWSIfaces(t *testing.T) {
+	unix := dynamodbattribute.UnixTime(time.Now())
+	av, err := Marshal(unix)
+	if err != nil {
+		t.Error(err)
+	}
+	official, err := dynamodbattribute.Marshal(unix)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(av, official) {
+		t.Error("marshal not equal.", av, "≠", official)
+	}
+
+	var result, officialResult dynamodbattribute.UnixTime
+	err = Unmarshal(official, &result)
+	if err != nil {
+		t.Error(err)
+	}
+	err = dynamodbattribute.Unmarshal(official, &officialResult)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(result, officialResult) {
+		t.Error("unmarshal not equal.", result, "≠", officialResult)
+	}
+}

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -98,6 +98,19 @@ var encodingTests = []struct {
 		in:   textMarshaler(true),
 		out:  &dynamodb.AttributeValue{S: aws.String("true")},
 	},
+	{
+		name: "dynamodb.AttributeValue",
+		in: &dynamodb.AttributeValue{L: []*dynamodb.AttributeValue{
+			{N: aws.String("1")},
+			{N: aws.String("2")},
+			{N: aws.String("3")},
+		}},
+		out: &dynamodb.AttributeValue{L: []*dynamodb.AttributeValue{
+			{N: aws.String("1")},
+			{N: aws.String("2")},
+			{N: aws.String("3")},
+		}},
+	},
 }
 
 var itemEncodingTests = []struct {
@@ -255,6 +268,19 @@ var itemEncodingTests = []struct {
 			M: map[string]interface{}{
 				"Hello": "world",
 			},
+		},
+		out: map[string]*dynamodb.AttributeValue{
+			"M": &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{
+				"Hello": &dynamodb.AttributeValue{S: aws.String("world")},
+			}},
+		},
+	},
+	{
+		name: "map string attributevalue",
+		in: map[string]*dynamodb.AttributeValue{
+			"M": &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{
+				"Hello": &dynamodb.AttributeValue{S: aws.String("world")},
+			}},
 		},
 		out: map[string]*dynamodb.AttributeValue{
 			"M": &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{


### PR DESCRIPTION
This pull req adds the following changes:
* dynamo's encoding/decoding process is bypassed when given `*dynamodb.AttributeValue` or `map[string]*dynamodb.AttributeValue` (thanks @mattaitchison!) 
* dynamo is now aware of [dynamodbattribute.(Un)marshaler](https://godoc.org/github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute#Marshaler) and will call into it when appropriate. 
* Added a wrapper that forces an object to use dynamodbattribute's (un)marshaling functions instead of ours (just call `dynamo.AWSEncoding(&obj)`).

This should help a bit with #28.