### PR TITLE
use DynamoDBAPI interface for easier unit testing

### DIFF
--- a/db.go
+++ b/db.go
@@ -5,11 +5,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 )
 
 // DB is a DynamoDB client.
 type DB struct {
-	client *dynamodb.DynamoDB
+	client dynamodbiface.DynamoDBAPI
 }
 
 // New creates a new client with the given configuration.


### PR DESCRIPTION
use the recommended `DynamoDBAPI` interface to allow easier unit testing and mocking as described in: https://godoc.org/github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface

