### PR TITLE
Add SetExpr for Update

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -31,6 +31,7 @@ type widget struct {
 	Time   time.Time // RK
 	Msg    string
 	Count  int
+	Meta   map[string]string
 }
 
 func isConditionalCheckErr(err error) bool {

--- a/update.go
+++ b/update.go
@@ -79,6 +79,14 @@ func (u *Update) SetIfNotExists(path string, value interface{}) *Update {
 	return u
 }
 
+// SetExpr specifies an expression for SET
+func (u *Update) SetExpr(expr string, args ...interface{}) *Update {
+	expr, err := u.subExpr(expr, args...)
+	u.setError(err)
+	u.set = append(u.set, expr)
+	return u
+}
+
 // Append appends value  to the end of the list specified by path.
 func (u *Update) Append(path string, value interface{}) *Update {
 	path, err := u.escape(path)

--- a/update_test.go
+++ b/update_test.go
@@ -18,6 +18,9 @@ func TestUpdate(t *testing.T) {
 		Time:   time.Now().UTC(),
 		Msg:    "hello",
 		Count:  0,
+		Meta: map[string]string{
+			"foo": "bar",
+		},
 	}
 	err := table.Put(item).Run()
 	if err != nil {
@@ -29,6 +32,7 @@ func TestUpdate(t *testing.T) {
 	err = table.Update("UserID", item.UserID).
 		Range("Time", item.Time).
 		Set("Msg", "changed").
+		SetExpr("Meta.$ = ?", "foo", "baz").
 		Add("Count", 1).
 		Add("Test", []string{"A", "B"}).
 		Value(&result)
@@ -37,6 +41,9 @@ func TestUpdate(t *testing.T) {
 		Time:   item.Time,
 		Msg:    "changed",
 		Count:  1,
+		Meta: map[string]string{
+			"foo": "baz",
+		},
 	}
 	if err != nil {
 		t.Error("unexpected error:", err)


### PR DESCRIPTION
This PR adds a `SetExpr` to Update. This allows user to write their own `SET` expression with placeholder names and values.

e.g.
To run a SET with
```
SET myMap.#k = :v 
```

Currently one can only do
```go
Set("myMap.'"+k+"'", v)
```

Which is kind of ugly and potentially unsafe, since it completely relies on `escape` to sanitize the input. This PR lets user do

```go
SetExpr("myMap.$ = ?", k, v)
```