### PR TITLE
Maps as sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,15 @@ import (
 type widget struct {
 	UserID int       // Hash key, a.k.a. partition key
 	Time   time.Time // Range key, a.k.a. sort key
-	
-	Msg       string   `dynamo:"Message"`
-	Count     int      `dynamo:",omitempty"`
-	Friends   []string `dynamo:",set"` // Sets 
-	SecretKey string   `dynamo:"-"`    // Ignored
-	Children  []any    // Lists
+
+	Msg       string              `dynamo:"Message"`
+	Count     int                 `dynamo:",omitempty"`
+	Friends   []string            `dynamo:",set"` // Sets
+	Set       map[string]struct{} `dynamo:",set"` // Map sets, too!
+	SecretKey string              `dynamo:"-"`    // Ignored
+	Children  []any               // Lists
 }
+
 
 func main() {
 	db := dynamo.New(session.New(), &aws.Config{Region: aws.String("us-west-2")})
@@ -42,9 +44,9 @@ func main() {
 	// get the same item 
 	var result widget
 	err = table.Get("UserID", w.UserID).
-			Range("Time", dynamo.Equal, w.Time).
-			Filter("'Count' = ? AND $ = ?", w.Count, "Message", w.Msg). // placeholders in expressions
-			One(&result)
+		Range("Time", dynamo.Equal, w.Time).
+		Filter("'Count' = ? AND $ = ?", w.Count, "Message", w.Msg). // placeholders in expressions
+		One(&result)
 	
 	// get all items
 	var results []widget

--- a/encode_test.go
+++ b/encode_test.go
@@ -1,8 +1,6 @@
 package dynamo
 
 import (
-	"github.com/kr/pretty"
-	// "log"
 	"reflect"
 	"testing"
 )
@@ -28,7 +26,6 @@ func TestMarshalItem(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(item, tc.out) {
-			t.Log(pretty.Sprint(pretty.Diff(item, tc.out)))
 			t.Errorf("%s: bad result: %#v ≠ %#v", tc.name, item, tc.out)
 		}
 	}

--- a/query.go
+++ b/query.go
@@ -47,7 +47,7 @@ var (
 // Operator is an operation to apply in key comparisons.
 type Operator *string
 
-// Operators used for comparing against the range key.
+// Operators used for comparing against the range key in queries.
 var (
 	Equal          = Operator(aws.String("EQ"))
 	NotEqual       = Operator(aws.String("NE"))

--- a/updatetable.go
+++ b/updatetable.go
@@ -21,8 +21,6 @@ type UpdateTable struct {
 	deleteIdx []string
 	ads       []*dynamodb.AttributeDefinition
 
-	subber
-
 	err error
 }
 

--- a/updatetable_test.go
+++ b/updatetable_test.go
@@ -25,6 +25,9 @@ func _TestUpdateTable(t *testing.T) {
 			Write: 1,
 		},
 	}).Run()
+
+	// desc, err := table.UpdateTable().DeleteIndex("test123").Run()
+
 	// spew.Dump(desc, err)
 	// desc, err := table.UpdateTable().Provision(2, 1).Run()
 	if err != nil {


### PR DESCRIPTION
This allows you to use `map[*]struct{}` and `map[*]bool` as a set, where the key type is `int*`, `uint*`, `string`, `float*`, or `[*]byte`.

This is a more natural way to store a set in Go, compared to a slice.