### PR TITLE
add ProjectExpr method to Query

### DIFF
--- a/query.go
+++ b/query.go
@@ -120,6 +120,17 @@ func (q *Query) Project(paths ...string) *Query {
 	return q
 }
 
+// ProjectExpr limits the result attributes to the given expression.
+// Use single quotes to specificy reserved names inline (like 'Count').
+// Use the placeholder ? within the expression to substitute values, and use $ for names.
+// You need to use quoted or placeholder names when the name is a reserved word in DynamoDB.
+func (q *Query) ProjectExpr(expr string, args ...interface{}) *Query {
+	expr, err := q.subExpr(expr, args...)
+	q.setError(err)
+	q.projection = expr
+	return q
+}
+
 // Filter takes an expression that all results will be evaluated against.
 // Use single quotes to specificy reserved names inline (like 'Count').
 // Use the placeholder ? within the expression to substitute values, and use $ for names.

--- a/query_test.go
+++ b/query_test.go
@@ -17,6 +17,10 @@ func TestGetAllCount(t *testing.T) {
 		UserID: 42,
 		Time:   time.Now().UTC(),
 		Msg:    "hello",
+		Meta: map[string]string{
+			"foo":        "bar",
+			"animal.cow": "moo",
+		},
 	}
 	err := table.Put(item).Run()
 	if err != nil {
@@ -77,6 +81,24 @@ func TestGetAllCount(t *testing.T) {
 		Time:   item.Time,
 	}
 	err = table.Get("UserID", 42).Range("Time", Equal, item.Time).Project("UserID", "Time").Consistent(true).One(&one)
+	if err != nil {
+		t.Error("unexpected error:", err)
+	}
+	if !reflect.DeepEqual(one, projected) {
+		t.Errorf("bad result for get one+project. %v ≠ %v", one, projected)
+	}
+
+	// GetItem + ProjectExpr
+	one = widget{}
+	projected = widget{
+		UserID: item.UserID,
+		Time:   item.Time,
+		Meta: map[string]string{
+			"foo":        "bar",
+			"animal.cow": "moo",
+		},
+	}
+	err = table.Get("UserID", 42).Range("Time", Equal, item.Time).ProjectExpr("UserID, $, Meta.foo, Meta.$", "Time", "animal.cow").Consistent(true).One(&one)
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}


### PR DESCRIPTION
In [Project Expression](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ProjectionExpressions.html) guide it says that if attribute name contains a character other than A-Z, a-z or 0-9 we should use [Expression Attribute Names](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html) 

I added a test code to show the case.

This method was also discussed at #38 