### PR TITLE
Fix query filter problem

### DIFF
--- a/query.go
+++ b/query.go
@@ -342,7 +342,7 @@ func (itr *queryIter) NextWithContext(ctx aws.Context, out interface{}) bool {
 	})
 
 	if itr.err != nil || len(itr.output.Items) == 0 {
-		return false
+		return itr.output.LastEvaluatedKey != nil
 	}
 
 	itr.err = itr.unmarshal(itr.output.Items[itr.idx], out)


### PR DESCRIPTION
The problem was with the search limit. When a filtered request result count isn't equal to requested limit a second query is called. If filtered result count isn't `0` another query is called but if result count is `0` then the rest of data will not be checked even if the `LastEvaluatedKey` is not nil. 

So I added a test code that adds `8` widgets that have counts `0`,`0`,`1`,`1`,`0`,`0`,`1`,`1`.
If search limit is set to `2` query will find only 2 results because there will be only 2 request that will check only 4( searchLimit * queryCount 2*2) results.

So I changed `NextWithContext` method to check for `LastEvaluatedKey` also. If `LastEvaluatedKey` is not nil another query will be called.


I don't know if test is at the correct place. If that's a problem I can remove and send the pr again.    
 