### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/put.go
+++ b/put.go
@@ -73,7 +73,7 @@ func (p *Put) OldValue(out interface{}) error {
 	return p.OldValueWithContext(ctx, out)
 }
 
-// OldValue executes this put, unmarshaling the previous value into out.
+// OldValueWithContext executes this put, unmarshaling the previous value into out.
 // Returns ErrNotFound is there was no previous value.
 func (p *Put) OldValueWithContext(ctx aws.Context, out interface{}) error {
 	p.returnType = "ALL_OLD"

--- a/tx.go
+++ b/tx.go
@@ -21,7 +21,7 @@ type GetTx struct {
 	cc           *ConsumedCapacity
 }
 
-// GetTransaction begins a new get transaction.
+// GetTx begins a new get transaction.
 func (db *DB) GetTx() *GetTx {
 	return &GetTx{
 		db: db,


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?