### PR TITLE
support dynamoattribute.UnixTime on CreateTable

### DIFF
--- a/createtable.go
+++ b/createtable.go
@@ -419,7 +419,8 @@ check:
 	case reflect.String:
 		return "S"
 	case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16,
-		reflect.Int8, reflect.Float64, reflect.Float32:
+		reflect.Int8, reflect.Float64, reflect.Float32,
+		reflect.Uint, reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
 		return "N"
 	case reflect.Slice, reflect.Array:
 		if typ.Elem().Kind() == reflect.Uint8 {

--- a/createtable.go
+++ b/createtable.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 )
 
 // StreamView determines what information is written to a table's stream.
@@ -407,6 +408,8 @@ func typeOf(rv reflect.Value) string {
 			}
 		case encoding.TextMarshaler:
 			return "S"
+		case dynamodbattribute.UnixTime, *dynamodbattribute.UnixTime:
+			return "N"
 		}
 	}
 

--- a/createtable_test.go
+++ b/createtable_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 )
 
 type UserAction struct {
@@ -19,6 +20,12 @@ type UserAction struct {
 
 type embeddedWithKeys struct {
 	Embedded **[]byte `index:"Embedded-index,hash"`
+}
+
+type Metric struct {
+	ID    uint64                     `dynamo:"ID,hash"`
+	Time  dynamodbattribute.UnixTime `dynamo:",range"`
+	Value uint64
 }
 
 func TestCreateTable(t *testing.T) {
@@ -105,4 +112,34 @@ func TestCreateTable(t *testing.T) {
 	if !reflect.DeepEqual(input, expected) {
 		t.Error("unexpected input", input)
 	}
+
+	t.Run("uint and UnixTime", func(t *testing.T) {
+		input := testDB.CreateTable("Metrics", Metric{}).
+			OnDemand(true).
+			input()
+		expected := &dynamodb.CreateTableInput{
+			AttributeDefinitions: []*dynamodb.AttributeDefinition{
+				{
+					AttributeName: aws.String("ID"),
+					AttributeType: aws.String("N"),
+				},
+				{
+					AttributeName: aws.String("Time"),
+					AttributeType: aws.String("N"),
+				},
+			},
+			KeySchema: []*dynamodb.KeySchemaElement{{
+				AttributeName: aws.String("ID"),
+				KeyType:       aws.String("HASH"),
+			}, {
+				AttributeName: aws.String("Time"),
+				KeyType:       aws.String("RANGE"),
+			}},
+			BillingMode: aws.String(dynamodb.BillingModePayPerRequest),
+			TableName:   aws.String("Metrics"),
+		}
+		if !reflect.DeepEqual(input, expected) {
+			t.Error("unexpected input", input)
+		}
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/guregu/dynamo
 
 require (
-	github.com/aws/aws-sdk-go v1.18.5
+	github.com/aws/aws-sdk-go v1.19.18
 	github.com/cenkalti/backoff v2.1.1+incompatible
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gofrs/uuid v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aws/aws-sdk-go v1.18.5 h1:S6j4o4AoJpq98DRc7wQrQsPZg73NyntGtUj6K6NPnuY=
 github.com/aws/aws-sdk-go v1.18.5/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.19.18 h1:Hb3+b9HCqrOrbAtFstUWg7H5TQ+/EcklJtE8VShVs8o=
+github.com/aws/aws-sdk-go v1.19.18/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/cenkalti/backoff v2.1.1+incompatible h1:tKJnvO2kl0zmb/jA5UKAt4VoEVw1qxKWjE/Bpp46npY=
 github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=


### PR DESCRIPTION
The `dynamodbattribute.UnixTime` is a type for storing UNIX epoch into DynamoDB that is officially provided by "aws-sdk-go". Isn't it reasonable to treat it as "N" dynamodb.AtributeType when creating a table?

How do you think?