### PR TITLE
add `unixtime` struct tag for time.Time

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"time"
 
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
@@ -42,6 +43,17 @@ func unmarshalReflect(av *dynamodb.AttributeValue, rv reflect.Value) error {
 			iface = rv.Addr().Interface()
 		} else {
 			iface = rv.Interface()
+		}
+
+		if x, ok := iface.(*time.Time); ok && av.N != nil {
+			// implicit unixtime
+			ts, err := strconv.ParseInt(*av.N, 10, 64)
+			if err != nil {
+				return err
+			}
+
+			*x = time.Unix(ts, 0).UTC()
+			return nil
 		}
 
 		switch x := iface.(type) {

--- a/encode.go
+++ b/encode.go
@@ -112,7 +112,13 @@ func marshal(v interface{}, special string) (*dynamodb.AttributeValue, error) {
 	switch x := v.(type) {
 	case time.Time:
 		if special != "unixtime" {
-			break // fall back to regular encoding
+			// fall back to regular encoding
+			break
+		}
+
+		if x.IsZero() {
+			// omitempty behaviour
+			return nil, nil
 		}
 
 		ts := strconv.FormatInt(x.Unix(), 10)

--- a/encode.go
+++ b/encode.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
@@ -106,6 +107,18 @@ func Marshal(v interface{}) (*dynamodb.AttributeValue, error) {
 
 func marshal(v interface{}, special string) (*dynamodb.AttributeValue, error) {
 	rv := reflect.ValueOf(v)
+
+	// encoders with precedence over interfaces
+	switch x := v.(type) {
+	case time.Time:
+		if special != "unixtime" {
+			break // fall back to regular encoding
+		}
+
+		ts := strconv.FormatInt(x.Unix(), 10)
+		return &dynamodb.AttributeValue{N: &ts}, nil
+	}
+
 	switch x := v.(type) {
 	case *dynamodb.AttributeValue:
 		return x, nil

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -390,6 +390,15 @@ var itemEncodingTests = []struct {
 			"TTL": &dynamodb.AttributeValue{N: aws.String("1546300800")},
 		},
 	},
+	{
+		name: "time.Time (zero unixtime encoding)",
+		in: struct {
+			TTL time.Time `dynamo:",unixtime"`
+		}{
+			TTL: time.Time{},
+		},
+		out: map[string]*dynamodb.AttributeValue{},
+	},
 }
 
 type embedded struct {

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -368,6 +368,28 @@ var itemEncodingTests = []struct {
 			}},
 		},
 	},
+	{
+		name: "time.Time (regular encoding)",
+		in: struct {
+			TTL time.Time
+		}{
+			TTL: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		out: map[string]*dynamodb.AttributeValue{
+			"TTL": &dynamodb.AttributeValue{S: aws.String("2019-01-01T00:00:00Z")},
+		},
+	},
+	{
+		name: "time.Time (unixtime encoding)",
+		in: struct {
+			TTL time.Time `dynamo:",unixtime"`
+		}{
+			TTL: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		out: map[string]*dynamodb.AttributeValue{
+			"TTL": &dynamodb.AttributeValue{N: aws.String("1546300800")},
+		},
+	},
 }
 
 type embedded struct {

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -399,6 +399,26 @@ var itemEncodingTests = []struct {
 		},
 		out: map[string]*dynamodb.AttributeValue{},
 	},
+	{
+		name: "*time.Time (unixtime encoding)",
+		in: struct {
+			TTL *time.Time `dynamo:",unixtime"`
+		}{
+			TTL: aws.Time(time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)),
+		},
+		out: map[string]*dynamodb.AttributeValue{
+			"TTL": &dynamodb.AttributeValue{N: aws.String("1546300800")},
+		},
+	},
+	{
+		name: "*time.Time (zero unixtime encoding)",
+		in: struct {
+			TTL *time.Time `dynamo:",unixtime"`
+		}{
+			TTL: nil,
+		},
+		out: map[string]*dynamodb.AttributeValue{},
+	},
 }
 
 type embedded struct {


### PR DESCRIPTION
Adds the `unixtime` struct tag, which behaves the same as its counterpart from AWS encoding as an alternative to wrapper types and the aws-sdk-go marshallers. The primary use-case is TTL fields, which mandate this encoding.

- When a `time.Time` or `*time.Time` field is marked `unixtime`, it is marshalled as a N-type attribute containing the `Unix()` value of the time.
- When a `time.Time` is being unmarshalled—and the source attribute is N-type—it is assumed that the encoding is `unixtime`. Some larger structural changes would have to be made in the decoder to eliminate the need for this assumption, as struct tags do not currently get passed sufficiently deep.

This is very much a convenience feature: I work a lot with TTL data in Dynamo, and have noticed that time.Time encoding (and consistency thereof) is often the first and only reason for splitting entity representations from domain models. Wrapper types leak the `dynamodbattribute` package, and the aws-sdk-go encoding comes with its own caveats around NULL behaviours and usage of the marshaler wrapper.

Related to https://github.com/guregu/dynamo/issues/83.
