### PR TITLE
Add table name alias an prefix support

### DIFF
--- a/createtable.go
+++ b/createtable.go
@@ -57,7 +57,8 @@ type CreateTable struct {
 
 // CreateTable begins a new operation to create a table with the given name.
 // The second parameter must be a struct with appropriate hash and range key struct tags
-// for the primary key and all indices.
+// for the primary key and all indices. The name of the table follows the same alias and
+// prefix resolution rules as db.Table().
 //
 // An example of a from struct follows:
 // 	type UserAction struct {
@@ -70,6 +71,8 @@ type CreateTable struct {
 // It creates two global secondary indices called UUID-index and Seq-ID-index,
 // and a local secondary index called ID-Seq-index.
 func (db *DB) CreateTable(name string, from interface{}) *CreateTable {
+	name = db.resolveTableName(name)
+
 	ct := &CreateTable{
 		db:            db,
 		tableName:     name,

--- a/createtable_test.go
+++ b/createtable_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"github.com/stretchr/testify/require"
 )
 
 type UserAction struct {
@@ -154,4 +155,13 @@ func TestCreateTableUintUnixTime(t *testing.T) {
 	if !reflect.DeepEqual(input2, expected) {
 		t.Error("unexpected input (unixtime tag)", input2)
 	}
+}
+
+func TestCreateTableAliasAndPrefix(t *testing.T) {
+	db := NewFromIface(nil)
+	db.Alias["Table1"] = "real-table-1"
+	db.Prefix = "Test-"
+
+	input := db.CreateTable("Table1", Metric{})
+	require.Equal(t, "Test-real-table-1", input.tableName)
 }

--- a/createtable_test.go
+++ b/createtable_test.go
@@ -159,9 +159,9 @@ func TestCreateTableUintUnixTime(t *testing.T) {
 
 func TestCreateTableAliasAndPrefix(t *testing.T) {
 	db := NewFromIface(nil)
-	db.Alias["Table1"] = "real-table-1"
-	db.Prefix = "Test-"
+	db.Alias["Alias1"] = "table1"
+	db.Prefix = "test-"
 
-	input := db.CreateTable("Table1", Metric{})
-	require.Equal(t, "Test-real-table-1", input.tableName)
+	input := db.CreateTable("Alias1", Metric{})
+	require.Equal(t, "test-table1", input.tableName)
 }

--- a/db.go
+++ b/db.go
@@ -13,19 +13,24 @@ import (
 // DB is a DynamoDB client.
 type DB struct {
 	client dynamodbiface.DynamoDBAPI
+	Alias  map[string]string // Maps table aliases to physical names.
 }
 
 // New creates a new client with the given configuration.
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *DB {
 	db := &DB{
-		dynamodb.New(p, cfgs...),
+		client: dynamodb.New(p, cfgs...),
+		Alias:  map[string]string{},
 	}
 	return db
 }
 
 // NewFromIface creates a new client with the given interface.
 func NewFromIface(client dynamodbiface.DynamoDBAPI) *DB {
-	return &DB{client}
+	return &DB{
+		client: client,
+		Alias:  map[string]string{},
+	}
 }
 
 // Client returns this DB's internal client used to make API requests.

--- a/db.go
+++ b/db.go
@@ -14,6 +14,7 @@ import (
 type DB struct {
 	client dynamodbiface.DynamoDBAPI
 	Alias  map[string]string // Maps table aliases to physical names.
+	Prefix string            // Prepended to table names.
 }
 
 // New creates a new client with the given configuration.

--- a/db.go
+++ b/db.go
@@ -39,6 +39,20 @@ func (db *DB) Client() dynamodbiface.DynamoDBAPI {
 	return db.client
 }
 
+func (db *DB) resolveTableName(name string) string {
+	if db == nil {
+		return name
+	}
+
+	if db.Alias != nil {
+		if v, ok := db.Alias[name]; ok {
+			name = v
+		}
+	}
+
+	return db.Prefix + name
+}
+
 // ListTables is a request to list tables.
 // See: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListTables.html
 type ListTables struct {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/cenkalti/backoff v2.1.1+incompatible
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gofrs/uuid v3.2.0+incompatible
-	github.com/stretchr/testify v1.3.0 // indirect
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20190318221613-d196dffd7c2b
 )
 

--- a/table.go
+++ b/table.go
@@ -30,14 +30,8 @@ type Table struct {
 // If the DB is configured with a prefix, it is prepended to the table name
 // regardless of whether an alias was used or not.
 func (db *DB) Table(name string) Table {
-	if db.Alias != nil {
-		if v, ok := db.Alias[name]; ok {
-			name = v
-		}
-	}
-
 	return Table{
-		name: db.Prefix + name,
+		name: db.resolveTableName(name),
 		db:   db,
 	}
 }

--- a/table.go
+++ b/table.go
@@ -25,8 +25,15 @@ type Table struct {
 	db   *DB
 }
 
-// Table returns a Table handle specified by name.
+// Table returns a Table handle specified by name. If an exact match to
+// name exists in the DB's alias map, the value of that is used instead.
 func (db *DB) Table(name string) Table {
+	if db.Alias != nil {
+		if v, ok := db.Alias[name]; ok {
+			name = v
+		}
+	}
+
 	return Table{
 		name: name,
 		db:   db,

--- a/table.go
+++ b/table.go
@@ -27,6 +27,8 @@ type Table struct {
 
 // Table returns a Table handle specified by name. If an exact match to
 // name exists in the DB's alias map, the value of that is used instead.
+// If the DB is configured with a prefix, it is prepended to the table name
+// regardless of whether an alias was used or not.
 func (db *DB) Table(name string) Table {
 	if db.Alias != nil {
 		if v, ok := db.Alias[name]; ok {
@@ -35,7 +37,7 @@ func (db *DB) Table(name string) Table {
 	}
 
 	return Table{
-		name: name,
+		name: db.Prefix + name,
 		db:   db,
 	}
 }

--- a/table_test.go
+++ b/table_test.go
@@ -61,14 +61,14 @@ func TestAddConsumedCapacity(t *testing.T) {
 
 func TestTableAliasAndPrefix(t *testing.T) {
 	db := NewFromIface(nil)
-	require.Equal(t, "MyTable", db.Table("MyTable").name)
+	require.Equal(t, "Alias1", db.Table("Alias1").name)
 
-	db.Alias["MyTable"] = "my-actual-table"
-	db.Alias["OtherTable"] = "my-other-table"
-	require.Equal(t, "my-actual-table", db.Table("MyTable").name)
-	require.Equal(t, "AnotherTable", db.Table("AnotherTable").name)
+	db.Alias["Alias1"] = "table1"
+	db.Alias["Alias2"] = "table2"
+	require.Equal(t, "table1", db.Table("Alias1").name)
+	require.Equal(t, "Alias3", db.Table("Alias3").name)
 
-	db.Prefix = "Test-"
-	require.Equal(t, "Test-my-actual-table", db.Table("MyTable").name)
-	require.Equal(t, "Test-AnotherTable", db.Table("AnotherTable").name)
+	db.Prefix = "test-"
+	require.Equal(t, "test-table1", db.Table("Alias1").name)
+	require.Equal(t, "test-Alias3", db.Table("Alias3").name)
 }

--- a/table_test.go
+++ b/table_test.go
@@ -59,14 +59,16 @@ func TestAddConsumedCapacity(t *testing.T) {
 	}
 }
 
-func TestTableAlias(t *testing.T) {
+func TestTableAliasAndPrefix(t *testing.T) {
 	db := NewFromIface(nil)
-
 	require.Equal(t, "MyTable", db.Table("MyTable").name)
 
 	db.Alias["MyTable"] = "my-actual-table"
 	db.Alias["OtherTable"] = "my-other-table"
-
 	require.Equal(t, "my-actual-table", db.Table("MyTable").name)
 	require.Equal(t, "AnotherTable", db.Table("AnotherTable").name)
+
+	db.Prefix = "Test-"
+	require.Equal(t, "Test-my-actual-table", db.Table("MyTable").name)
+	require.Equal(t, "Test-AnotherTable", db.Table("AnotherTable").name)
 }

--- a/table_test.go
+++ b/table_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddConsumedCapacity(t *testing.T) {
@@ -56,4 +57,16 @@ func TestAddConsumedCapacity(t *testing.T) {
 	if !reflect.DeepEqual(cc, expected) {
 		t.Error("bad ConsumedCapacity:", cc, "≠", expected)
 	}
+}
+
+func TestTableAlias(t *testing.T) {
+	db := NewFromIface(nil)
+
+	require.Equal(t, "MyTable", db.Table("MyTable").name)
+
+	db.Alias["MyTable"] = "my-actual-table"
+	db.Alias["OtherTable"] = "my-other-table"
+
+	require.Equal(t, "my-actual-table", db.Table("MyTable").name)
+	require.Equal(t, "AnotherTable", db.Table("AnotherTable").name)
 }


### PR DESCRIPTION
Adds table name aliasing and an optional table name prefix. Both are configured at `dynamo.DB` level.

It's similar to what's offered by the [AWS .NET Core SDK](https://aws.amazon.com/blogs/developer/enhancements-to-the-dynamodb-sdk/).

In a call to `db.Table(name)` or `db.CreateTable(name, ...)`: if the `name` is a key in the `db`'s alias mapping, it is replaced by its value in the alias mapping. Finally, the prefix is prepended to the name. The alias mapping and prefix are initially empty, so the default behaviour remains unchanged.

This is a convenience feature for applications that must permit overrides of individual table names, allowing for this configuration to be decoupled from the construction of `dynamo.Table`. By setting up a randomly generated prefix, it can also simplify testing where `dynamo.DB` is involved.