### PR TITLE
update doc on the number of transactions supported

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -11,7 +11,7 @@ type getTxOp interface {
 }
 
 // GetTx is a transaction to retrieve items.
-// It can contain up to 10 operations and works across multiple tables.
+// It can contain up to 25 operations and works across multiple tables.
 // GetTx is analogous to TransactGetItems in DynamoDB's API.
 // See: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactGetItems.html
 type GetTx struct {
@@ -162,7 +162,7 @@ type writeTxOp interface {
 }
 
 // WriteTx is a transaction to delete, put, update, and check items.
-// It can contain up to 10 operations and works across multiple tables.
+// It can contain up to 25 operations and works across multiple tables.
 // Two operations cannot target the same item.
 // WriteTx is analogous to TransactWriteItems in DynamoDB's API.
 // See: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html


### PR DESCRIPTION
The TransactGetItems API and the TransactWriteItems API are now supported for up to 25 items.

ref: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html