### PR TITLE
feat(update): add or del int64 value from Set

### DIFF
--- a/update.go
+++ b/update.go
@@ -170,7 +170,7 @@ func (u *Update) AddStringsToSet(path string, values ...string) *Update {
 }
 
 // AddIntsToSet adds the given values to the number set specified by path.
-func (u *Update) AddIntsToSet(path string, values ...int) *Update {
+func (u *Update) AddIntsToSet(path string, values ...int64) *Update {
 	return u.Add(path, values)
 }
 
@@ -194,7 +194,7 @@ func (u *Update) DeleteStringsFromSet(path string, values ...string) *Update {
 }
 
 // DeleteIntsFromSet deletes the given values from the number set specified by path.
-func (u *Update) DeleteIntsFromSet(path string, values ...int) *Update {
+func (u *Update) DeleteIntsFromSet(path string, values ...int64) *Update {
 	return u.delete(path, values)
 }
 


### PR DESCRIPTION
I encountered this limitation when I add an int64 value via AddIntsToSet func.
DynamoDB is able to support int64 value on NumberSet, so I want to update this function using int64 values.

I considered adding `AddInt64sToSet` and `DeleteInt64sFromSet` funcs, but other funcs such as `AddFloatsToSet` and `DeleteFloatsFromSet` are already using `float64` .

Please check this PR to resolve this kind of limitation.