### PR TITLE
fix err check when decoding number set

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -206,7 +206,7 @@ func unmarshalReflect(av *dynamodb.AttributeValue, rv reflect.Value) error {
 			kv := reflect.New(rv.Type().Key()).Elem()
 			for _, n := range av.NS {
 				if err := unmarshalReflect(&dynamodb.AttributeValue{N: n}, kv); err != nil {
-					return nil
+					return err
 				}
 				rv.SetMapIndex(kv, truthy)
 			}


### PR DESCRIPTION
not sure exactly why, but this faulty return resulted in decoding a NS into a `map[int]struct{}` to fail, despite the NS being valid. couldn't seem to reproduce with a unit test, unfortunately