### PR TITLE
Add attribute for SetExpr

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ func main() {
 
 ### Expressions
 
-dynamo will help you write expressions used to filter results in queries and scans, and add conditions to puts and deletes. 
+dynamo will help you write expressions used to filter results in queries and scans, and add conditions to puts and deletes.
 
 Attribute names may be written as is if it is not a reserved word, or be escaped with single quotes (`''`). You may also use dollar signs (`$`) as placeholders for attribute names. DynamoDB has [very large amount of reserved words](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html) so it may be a good idea to just escape everything.
 
@@ -114,7 +114,7 @@ err := db.Table("Books").Get("ID", 555).One(dynamo.AWSEncoding(&someBook))
 
 ### Integration tests
 
-By default, tests are run in offline mode. Create a table called `TestDB`, with a Number Parition Key called `UserID` and a String Sort Key called `Time`. Change the table name with the environment variable `DYNAMO_TEST_TABLE`. You must specify `DYNAMO_TEST_REGION`, setting it to the AWS region where your test table is.
+By default, tests are run in offline mode. Create a table called `TestDB`, with a Number Partition Key called `UserID` and a String Sort Key called `Time`. Change the table name with the environment variable `DYNAMO_TEST_TABLE`. You must specify `DYNAMO_TEST_REGION`, setting it to the AWS region where your test table is.
 
  ```bash
 DYNAMO_TEST_REGION=us-west-2 go test github.com/guregu/dynamo/... -cover

--- a/update_test.go
+++ b/update_test.go
@@ -28,6 +28,7 @@ func TestUpdate(t *testing.T) {
 			Count:  0,
 			Meta: map[string]string{
 				"foo":  "bar",
+				"keep": "untouched",
 				"nope": "痛",
 			},
 		},
@@ -65,6 +66,7 @@ func TestUpdate(t *testing.T) {
 			Count:  1,
 			Meta: map[string]string{
 				"foo": "baz",
+				"keep": "untouched",
 			},
 		},
 		MySet1: []string{"one"},


### PR DESCRIPTION
I think it's worth adding an additional attribute to ensure
`SetExpr` doesn't blow away the other attributes that its not
supposed to touch. There is a second one, but it's removed
later with `RemoveExpr`. This PR adds an attribute to `Meta` that
remains untouched.