### PR TITLE
Iterators check if the context is canceled

### DIFF
--- a/batchget.go
+++ b/batchget.go
@@ -199,6 +199,9 @@ func (itr *bgIter) Next(out interface{}) bool {
 
 func (itr *bgIter) NextWithContext(ctx aws.Context, out interface{}) bool {
 	// stop if we have an error
+	if ctx.Err() != nil {
+		itr.err = ctx.Err()
+	}
 	if itr.err != nil {
 		return false
 	}

--- a/db.go
+++ b/db.go
@@ -82,6 +82,9 @@ func (itr *ltIter) Next(out interface{}) bool {
 }
 
 func (itr *ltIter) NextWithContext(ctx aws.Context, out interface{}) bool {
+	if ctx.Err() != nil {
+		itr.err = ctx.Err()
+	}
 	if itr.err != nil {
 		return false
 	}

--- a/query.go
+++ b/query.go
@@ -325,6 +325,9 @@ func (itr *queryIter) Next(out interface{}) bool {
 
 func (itr *queryIter) NextWithContext(ctx aws.Context, out interface{}) bool {
 	// stop if we have an error
+	if ctx.Err() != nil {
+		itr.err = ctx.Err()
+	}
 	if itr.err != nil {
 		return false
 	}

--- a/scan.go
+++ b/scan.go
@@ -251,6 +251,9 @@ func (itr *scanIter) Next(out interface{}) bool {
 
 func (itr *scanIter) NextWithContext(ctx aws.Context, out interface{}) bool {
 	// stop if we have an error
+	if ctx.Err() != nil {
+		itr.err = ctx.Err()
+	}
 	if itr.err != nil {
 		return false
 	}


### PR DESCRIPTION
I think it'd be better that each iterator's `NextWithContext` returns early if the given context is already canceled. Otherwise, they try to unmarshal an item if `iter.output` already has a response.

It can be the caller's responsibility to avoid calling `NextWithContext` after the context gets canceled. However, it requires this kind of context check in every loop:

```go
for ctx.Err() != nil && iter.NextWithContext(ctx, &out){
    ...
}
if ctx.Err() != nil { return ctx.Err() }
```

If `NextWithContext` does it instead of the caller, we can avoid such duplicated code.