### PR TITLE
Simplify code using gofmt

### DIFF
--- a/createtable.go
+++ b/createtable.go
@@ -152,7 +152,7 @@ func (ct *CreateTable) Project(index string, projection IndexProjection, include
 func (ct *CreateTable) Index(index Index) *CreateTable {
 	ct.add(index.HashKey, string(index.HashKeyType))
 	ks := []*dynamodb.KeySchemaElement{
-		&dynamodb.KeySchemaElement{
+		{
 			AttributeName: &index.HashKey,
 			KeyType:       aws.String(dynamodb.KeyTypeHash),
 		},

--- a/createtable_test.go
+++ b/createtable_test.go
@@ -107,7 +107,7 @@ func TestCreateTable(t *testing.T) {
 			WriteCapacityUnits: aws.Int64(2),
 		},
 		Tags: []*dynamodb.Tag{
-			&dynamodb.Tag{
+			{
 				Key:   aws.String("Tag-Key"),
 				Value: aws.String("Tag-Value"),
 			},

--- a/decode_test.go
+++ b/decode_test.go
@@ -17,7 +17,7 @@ var itemDecodeOnlyTests = []struct {
 		// unexported embedded pointers should be ignored
 		name: "embedded unexported pointer",
 		given: map[string]*dynamodb.AttributeValue{
-			"Embedded": &dynamodb.AttributeValue{BOOL: aws.Bool(true)},
+			"Embedded": {BOOL: aws.Bool(true)},
 		},
 		expect: struct {
 			*embedded
@@ -27,7 +27,7 @@ var itemDecodeOnlyTests = []struct {
 		// unexported fields should be ignored
 		name: "unexported fields",
 		given: map[string]*dynamodb.AttributeValue{
-			"a": &dynamodb.AttributeValue{BOOL: aws.Bool(true)},
+			"a": {BOOL: aws.Bool(true)},
 		},
 		expect: struct {
 			a bool
@@ -37,7 +37,7 @@ var itemDecodeOnlyTests = []struct {
 		// embedded pointers shouldn't clobber existing fields
 		name: "exported pointer embedded struct clobber",
 		given: map[string]*dynamodb.AttributeValue{
-			"Embedded": &dynamodb.AttributeValue{S: aws.String("OK")},
+			"Embedded": {S: aws.String("OK")},
 		},
 		expect: struct {
 			Embedded string
@@ -76,10 +76,10 @@ func TestUnmarshalAppend(t *testing.T) {
 	limit := "20"
 	null := true
 	item := map[string]*dynamodb.AttributeValue{
-		"UserID": &dynamodb.AttributeValue{N: &id},
-		"Page":   &dynamodb.AttributeValue{N: &page},
-		"Limit":  &dynamodb.AttributeValue{N: &limit},
-		"Null":   &dynamodb.AttributeValue{NULL: &null},
+		"UserID": {N: &id},
+		"Page":   {N: &page},
+		"Limit":  {N: &limit},
+		"Null":   {NULL: &null},
 	}
 
 	for range [15]struct{}{} {
@@ -144,13 +144,13 @@ func TestUnmarshalNULL(t *testing.T) {
 	arbitrary := "hello world"
 	double := new(*int)
 	item := map[string]*dynamodb.AttributeValue{
-		"String":    &dynamodb.AttributeValue{NULL: &tru},
-		"Slice":     &dynamodb.AttributeValue{NULL: &tru},
-		"Array":     &dynamodb.AttributeValue{NULL: &tru},
-		"StringPtr": &dynamodb.AttributeValue{NULL: &tru},
-		"DoublePtr": &dynamodb.AttributeValue{NULL: &tru},
-		"Map":       &dynamodb.AttributeValue{NULL: &tru},
-		"Interface": &dynamodb.AttributeValue{NULL: &tru},
+		"String":    {NULL: &tru},
+		"Slice":     {NULL: &tru},
+		"Array":     {NULL: &tru},
+		"StringPtr": {NULL: &tru},
+		"DoublePtr": {NULL: &tru},
+		"Map":       {NULL: &tru},
+		"Interface": {NULL: &tru},
 	}
 
 	type resultType struct {

--- a/encode_test.go
+++ b/encode_test.go
@@ -27,9 +27,9 @@ var itemEncodeOnlyTests = []struct {
 			Other: true,
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"L":     &dynamodb.AttributeValue{L: []*dynamodb.AttributeValue{}},
-			"M":     &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{}},
-			"Other": &dynamodb.AttributeValue{BOOL: aws.Bool(true)},
+			"L":     {L: []*dynamodb.AttributeValue{}},
+			"M":     {M: map[string]*dynamodb.AttributeValue{}},
+			"Other": {BOOL: aws.Bool(true)},
 		},
 	},
 	{
@@ -44,7 +44,7 @@ var itemEncodeOnlyTests = []struct {
 			Other: true,
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"Other": &dynamodb.AttributeValue{BOOL: aws.Bool(true)},
+			"Other": {BOOL: aws.Bool(true)},
 		},
 	},
 	{
@@ -59,7 +59,7 @@ var itemEncodeOnlyTests = []struct {
 			private2: new(int),
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"Public": &dynamodb.AttributeValue{N: aws.String("555")},
+			"Public": {N: aws.String("555")},
 		},
 	},
 }

--- a/encoding_aws_test.go
+++ b/encoding_aws_test.go
@@ -133,8 +133,8 @@ func TestAWSUnmarshalAppend(t *testing.T) {
 		B: 222,
 	}
 	err := unmarshalAppend(map[string]*dynamodb.AttributeValue{
-		"one": &dynamodb.AttributeValue{S: aws.String("test")},
-		"two": &dynamodb.AttributeValue{N: aws.String("555")},
+		"one": {S: aws.String("test")},
+		"two": {N: aws.String("555")},
 	}, AWSEncoding(&list))
 	if err != nil {
 		t.Error(err)
@@ -143,8 +143,8 @@ func TestAWSUnmarshalAppend(t *testing.T) {
 		t.Error("bad AWS unmarshal append:", list)
 	}
 	err = unmarshalAppend(map[string]*dynamodb.AttributeValue{
-		"one": &dynamodb.AttributeValue{S: aws.String("two")},
-		"two": &dynamodb.AttributeValue{N: aws.String("222")},
+		"one": {S: aws.String("two")},
+		"two": {N: aws.String("222")},
 	}, AWSEncoding(&list))
 	if err != nil {
 		t.Error(err)

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -65,7 +65,7 @@ var encodingTests = []struct {
 			"OK": true,
 		},
 		out: &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{
-			"OK": &dynamodb.AttributeValue{BOOL: aws.Bool(true)},
+			"OK": {BOOL: aws.Bool(true)},
 		}},
 	},
 	{
@@ -77,7 +77,7 @@ var encodingTests = []struct {
 			Empty: map[string]bool{},
 		},
 		out: &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{
-			"Empty": &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{}},
+			"Empty": {M: map[string]*dynamodb.AttributeValue{}},
 		}},
 	},
 	{
@@ -88,8 +88,8 @@ var encodingTests = []struct {
 			M1: map[textMarshaler]bool{textMarshaler(true): true},
 		},
 		out: &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{
-			"M1": &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{
-				"true": &dynamodb.AttributeValue{BOOL: aws.Bool(true)},
+			"M1": {M: map[string]*dynamodb.AttributeValue{
+				"true": {BOOL: aws.Bool(true)},
 			}},
 		}},
 	},
@@ -99,7 +99,7 @@ var encodingTests = []struct {
 			OK bool
 		}{OK: true},
 		out: &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{
-			"OK": &dynamodb.AttributeValue{BOOL: aws.Bool(true)},
+			"OK": {BOOL: aws.Bool(true)},
 		}},
 	},
 	{
@@ -210,7 +210,7 @@ var encodingTests = []struct {
 	},
 	{
 		name: "slice with empty binary",
-		in:   [][]byte{[]byte{}, []byte("hello"), []byte{}, []byte("world"), []byte{}},
+		in:   [][]byte{{}, []byte("hello"), {}, []byte("world"), {}},
 		out: &dynamodb.AttributeValue{L: []*dynamodb.AttributeValue{
 			{B: []byte{}},
 			{B: []byte{'h', 'e', 'l', 'l', 'o'}},
@@ -221,7 +221,7 @@ var encodingTests = []struct {
 	},
 	{
 		name: "array with empty binary",
-		in:   [...][]byte{[]byte{}, []byte("hello"), []byte{}, []byte("world"), []byte{}},
+		in:   [...][]byte{{}, []byte("hello"), {}, []byte("world"), {}},
 		out: &dynamodb.AttributeValue{L: []*dynamodb.AttributeValue{
 			{B: []byte{}},
 			{B: []byte{'h', 'e', 'l', 'l', 'o'}},
@@ -256,7 +256,7 @@ var itemEncodingTests = []struct {
 			A: "hello",
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"A": &dynamodb.AttributeValue{S: aws.String("hello")},
+			"A": {S: aws.String("hello")},
 		},
 	},
 	{
@@ -267,7 +267,7 @@ var itemEncodingTests = []struct {
 			A: "hello",
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"A": &dynamodb.AttributeValue{S: aws.String("hello")},
+			"A": {S: aws.String("hello")},
 		},
 	},
 	{
@@ -278,7 +278,7 @@ var itemEncodingTests = []struct {
 			A: new(textMarshaler),
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"A": &dynamodb.AttributeValue{S: aws.String("false")},
+			"A": {S: aws.String("false")},
 		},
 	},
 	{
@@ -289,7 +289,7 @@ var itemEncodingTests = []struct {
 			A: "hello",
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"renamed": &dynamodb.AttributeValue{S: aws.String("hello")},
+			"renamed": {S: aws.String("hello")},
 		},
 	},
 	{
@@ -302,7 +302,7 @@ var itemEncodingTests = []struct {
 			Other: true,
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"Other": &dynamodb.AttributeValue{BOOL: aws.Bool(true)},
+			"Other": {BOOL: aws.Bool(true)},
 		},
 	},
 	{
@@ -317,7 +317,7 @@ var itemEncodingTests = []struct {
 			Other: true,
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"Other": &dynamodb.AttributeValue{BOOL: aws.Bool(true)},
+			"Other": {BOOL: aws.Bool(true)},
 		},
 	},
 	{
@@ -340,8 +340,8 @@ var itemEncodingTests = []struct {
 			EmptyL: []int{},
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"OK":     &dynamodb.AttributeValue{S: aws.String("OK")},
-			"EmptyL": &dynamodb.AttributeValue{L: []*dynamodb.AttributeValue{}},
+			"OK":     {S: aws.String("OK")},
+			"EmptyL": {L: []*dynamodb.AttributeValue{}},
 		},
 	},
 	{
@@ -353,8 +353,8 @@ var itemEncodingTests = []struct {
 			B: []byte{},
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"S": &dynamodb.AttributeValue{S: aws.String("")},
-			"B": &dynamodb.AttributeValue{B: []byte{}},
+			"S": {S: aws.String("")},
+			"B": {B: []byte{}},
 		},
 	},
 	{
@@ -365,10 +365,10 @@ var itemEncodingTests = []struct {
 			M: map[string]*string{"null": nil, "empty": aws.String(""), "normal": aws.String("hello")},
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"M": &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{
-				"null":   &dynamodb.AttributeValue{NULL: aws.Bool(true)},
-				"empty":  &dynamodb.AttributeValue{S: aws.String("")},
-				"normal": &dynamodb.AttributeValue{S: aws.String("hello")},
+			"M": {M: map[string]*dynamodb.AttributeValue{
+				"null":   {NULL: aws.Bool(true)},
+				"empty":  {S: aws.String("")},
+				"normal": {S: aws.String("hello")},
 			}},
 		},
 	},
@@ -382,11 +382,11 @@ var itemEncodingTests = []struct {
 			SS      []string           `dynamo:",null,set"`
 		}{},
 		out: map[string]*dynamodb.AttributeValue{
-			"S":       &dynamodb.AttributeValue{NULL: aws.Bool(true)},
-			"B":       &dynamodb.AttributeValue{NULL: aws.Bool(true)},
-			"NilTime": &dynamodb.AttributeValue{NULL: aws.Bool(true)},
-			"M":       &dynamodb.AttributeValue{NULL: aws.Bool(true)},
-			"SS":      &dynamodb.AttributeValue{NULL: aws.Bool(true)},
+			"S":       {NULL: aws.Bool(true)},
+			"B":       {NULL: aws.Bool(true)},
+			"NilTime": {NULL: aws.Bool(true)},
+			"M":       {NULL: aws.Bool(true)},
+			"SS":      {NULL: aws.Bool(true)},
 		},
 	},
 	{
@@ -399,7 +399,7 @@ var itemEncodingTests = []struct {
 			},
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"Embedded": &dynamodb.AttributeValue{BOOL: aws.Bool(true)},
+			"Embedded": {BOOL: aws.Bool(true)},
 		},
 	},
 	{
@@ -412,7 +412,7 @@ var itemEncodingTests = []struct {
 			},
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"Embedded": &dynamodb.AttributeValue{BOOL: aws.Bool(true)},
+			"Embedded": {BOOL: aws.Bool(true)},
 		},
 	},
 	{
@@ -425,7 +425,7 @@ var itemEncodingTests = []struct {
 			},
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"Embedded": &dynamodb.AttributeValue{BOOL: aws.Bool(true)},
+			"Embedded": {BOOL: aws.Bool(true)},
 		},
 	},
 	{
@@ -437,7 +437,7 @@ var itemEncodingTests = []struct {
 			Embedded: "OK",
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"Embedded": &dynamodb.AttributeValue{S: aws.String("OK")},
+			"Embedded": {S: aws.String("OK")},
 		},
 	},
 	{
@@ -449,7 +449,7 @@ var itemEncodingTests = []struct {
 			Embedded: "OK",
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"Embedded": &dynamodb.AttributeValue{S: aws.String("OK")},
+			"Embedded": {S: aws.String("OK")},
 		},
 	},
 	{
@@ -461,7 +461,7 @@ var itemEncodingTests = []struct {
 			Embedded: "OK",
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"Embedded": &dynamodb.AttributeValue{S: aws.String("OK")},
+			"Embedded": {S: aws.String("OK")},
 		},
 	},
 	{
@@ -489,44 +489,44 @@ var itemEncodingTests = []struct {
 		}{
 			SS1:  []string{"A", "B"},
 			SS2:  []textMarshaler{textMarshaler(true), textMarshaler(false)},
-			SS3:  map[string]struct{}{"A": struct{}{}},
+			SS3:  map[string]struct{}{"A": {}},
 			SS4:  map[string]bool{"A": true},
-			SS5:  map[customString]struct{}{"A": struct{}{}},
+			SS5:  map[customString]struct{}{"A": {}},
 			SS6:  []customString{"A", "B"},
-			SS7:  map[textMarshaler]struct{}{textMarshaler(true): struct{}{}},
+			SS7:  map[textMarshaler]struct{}{textMarshaler(true): {}},
 			SS8:  map[textMarshaler]bool{textMarshaler(false): true},
 			SS9:  []string{"A", "B", ""},
-			SS10: map[string]customEmpty{"A": customEmpty{}},
-			BS1:  [][]byte{[]byte{'A'}, []byte{'B'}},
-			BS2:  map[[1]byte]struct{}{[1]byte{'A'}: struct{}{}},
-			BS3:  map[[1]byte]bool{[1]byte{'A'}: true},
-			BS4:  [][]byte{[]byte{'A'}, []byte{'B'}, []byte{}},
+			SS10: map[string]customEmpty{"A": {}},
+			BS1:  [][]byte{{'A'}, {'B'}},
+			BS2:  map[[1]byte]struct{}{{'A'}: {}},
+			BS3:  map[[1]byte]bool{{'A'}: true},
+			BS4:  [][]byte{{'A'}, {'B'}, {}},
 			NS1:  []int{1, 2},
 			NS2:  []float64{1, 2},
 			NS3:  []uint{1, 2},
-			NS4:  map[int]struct{}{maxInt: struct{}{}},
+			NS4:  map[int]struct{}{maxInt: {}},
 			NS5:  map[uint]bool{maxUint: true},
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"SS1":  &dynamodb.AttributeValue{SS: []*string{aws.String("A"), aws.String("B")}},
-			"SS2":  &dynamodb.AttributeValue{SS: []*string{aws.String("true"), aws.String("false")}},
-			"SS3":  &dynamodb.AttributeValue{SS: []*string{aws.String("A")}},
-			"SS4":  &dynamodb.AttributeValue{SS: []*string{aws.String("A")}},
-			"SS5":  &dynamodb.AttributeValue{SS: []*string{aws.String("A")}},
-			"SS6":  &dynamodb.AttributeValue{SS: []*string{aws.String("A"), aws.String("B")}},
-			"SS7":  &dynamodb.AttributeValue{SS: []*string{aws.String("true")}},
-			"SS8":  &dynamodb.AttributeValue{SS: []*string{aws.String("false")}},
-			"SS9":  &dynamodb.AttributeValue{SS: []*string{aws.String("A"), aws.String("B"), aws.String("")}},
-			"SS10": &dynamodb.AttributeValue{SS: []*string{aws.String("A")}},
-			"BS1":  &dynamodb.AttributeValue{BS: [][]byte{[]byte{'A'}, []byte{'B'}}},
-			"BS2":  &dynamodb.AttributeValue{BS: [][]byte{[]byte{'A'}}},
-			"BS3":  &dynamodb.AttributeValue{BS: [][]byte{[]byte{'A'}}},
-			"BS4":  &dynamodb.AttributeValue{BS: [][]byte{[]byte{'A'}, []byte{'B'}, []byte{}}},
-			"NS1":  &dynamodb.AttributeValue{NS: []*string{aws.String("1"), aws.String("2")}},
-			"NS2":  &dynamodb.AttributeValue{NS: []*string{aws.String("1"), aws.String("2")}},
-			"NS3":  &dynamodb.AttributeValue{NS: []*string{aws.String("1"), aws.String("2")}},
-			"NS4":  &dynamodb.AttributeValue{NS: []*string{aws.String(maxIntStr)}},
-			"NS5":  &dynamodb.AttributeValue{NS: []*string{aws.String(maxUintStr)}},
+			"SS1":  {SS: []*string{aws.String("A"), aws.String("B")}},
+			"SS2":  {SS: []*string{aws.String("true"), aws.String("false")}},
+			"SS3":  {SS: []*string{aws.String("A")}},
+			"SS4":  {SS: []*string{aws.String("A")}},
+			"SS5":  {SS: []*string{aws.String("A")}},
+			"SS6":  {SS: []*string{aws.String("A"), aws.String("B")}},
+			"SS7":  {SS: []*string{aws.String("true")}},
+			"SS8":  {SS: []*string{aws.String("false")}},
+			"SS9":  {SS: []*string{aws.String("A"), aws.String("B"), aws.String("")}},
+			"SS10": {SS: []*string{aws.String("A")}},
+			"BS1":  {BS: [][]byte{{'A'}, {'B'}}},
+			"BS2":  {BS: [][]byte{{'A'}}},
+			"BS3":  {BS: [][]byte{{'A'}}},
+			"BS4":  {BS: [][]byte{{'A'}, {'B'}, {}}},
+			"NS1":  {NS: []*string{aws.String("1"), aws.String("2")}},
+			"NS2":  {NS: []*string{aws.String("1"), aws.String("2")}},
+			"NS3":  {NS: []*string{aws.String("1"), aws.String("2")}},
+			"NS4":  {NS: []*string{aws.String(maxIntStr)}},
+			"NS5":  {NS: []*string{aws.String(maxUintStr)}},
 		},
 	},
 	{
@@ -541,16 +541,16 @@ var itemEncodingTests = []struct {
 			},
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"S": &dynamodb.AttributeValue{S: aws.String("Hello")},
-			"B": &dynamodb.AttributeValue{B: []byte{'A', 'B'}},
-			"N": &dynamodb.AttributeValue{N: aws.String("1.2")},
-			"L": &dynamodb.AttributeValue{L: []*dynamodb.AttributeValue{
-				&dynamodb.AttributeValue{S: aws.String("A")},
-				&dynamodb.AttributeValue{S: aws.String("B")},
-				&dynamodb.AttributeValue{N: aws.String("1.2")},
+			"S": {S: aws.String("Hello")},
+			"B": {B: []byte{'A', 'B'}},
+			"N": {N: aws.String("1.2")},
+			"L": {L: []*dynamodb.AttributeValue{
+				{S: aws.String("A")},
+				{S: aws.String("B")},
+				{N: aws.String("1.2")},
 			}},
-			"M": &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{
-				"OK": &dynamodb.AttributeValue{BOOL: aws.Bool(true)},
+			"M": {M: map[string]*dynamodb.AttributeValue{
+				"OK": {BOOL: aws.Bool(true)},
 			}},
 		},
 	},
@@ -564,21 +564,21 @@ var itemEncodingTests = []struct {
 			},
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"M": &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{
-				"Hello": &dynamodb.AttributeValue{S: aws.String("world")},
+			"M": {M: map[string]*dynamodb.AttributeValue{
+				"Hello": {S: aws.String("world")},
 			}},
 		},
 	},
 	{
 		name: "map string attributevalue",
 		in: map[string]*dynamodb.AttributeValue{
-			"M": &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{
-				"Hello": &dynamodb.AttributeValue{S: aws.String("world")},
+			"M": {M: map[string]*dynamodb.AttributeValue{
+				"Hello": {S: aws.String("world")},
 			}},
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"M": &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{
-				"Hello": &dynamodb.AttributeValue{S: aws.String("world")},
+			"M": {M: map[string]*dynamodb.AttributeValue{
+				"Hello": {S: aws.String("world")},
 			}},
 		},
 	},
@@ -590,7 +590,7 @@ var itemEncodingTests = []struct {
 			TTL: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"TTL": &dynamodb.AttributeValue{S: aws.String("2019-01-01T00:00:00Z")},
+			"TTL": {S: aws.String("2019-01-01T00:00:00Z")},
 		},
 	},
 	{
@@ -601,7 +601,7 @@ var itemEncodingTests = []struct {
 			TTL: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"TTL": &dynamodb.AttributeValue{N: aws.String("1546300800")},
+			"TTL": {N: aws.String("1546300800")},
 		},
 	},
 	{
@@ -621,7 +621,7 @@ var itemEncodingTests = []struct {
 			TTL: aws.Time(time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)),
 		},
 		out: map[string]*dynamodb.AttributeValue{
-			"TTL": &dynamodb.AttributeValue{N: aws.String("1546300800")},
+			"TTL": {N: aws.String("1546300800")},
 		},
 	},
 	{
@@ -637,14 +637,14 @@ var itemEncodingTests = []struct {
 		name: "dynamodb.ItemUnmarshaler",
 		in:   customItemMarshaler{Thing: 52},
 		out: map[string]*dynamodb.AttributeValue{
-			"thing": &dynamodb.AttributeValue{N: aws.String("52")},
+			"thing": {N: aws.String("52")},
 		},
 	},
 	{
 		name: "*dynamodb.ItemUnmarshaler",
 		in:   &customItemMarshaler{Thing: 52},
 		out: map[string]*dynamodb.AttributeValue{
-			"thing": &dynamodb.AttributeValue{N: aws.String("52")},
+			"thing": {N: aws.String("52")},
 		},
 	},
 }
@@ -713,7 +713,7 @@ type customItemMarshaler struct {
 func (cim *customItemMarshaler) MarshalDynamoItem() (map[string]*dynamodb.AttributeValue, error) {
 	thing := strconv.Itoa(cim.Thing.(int))
 	attrs := map[string]*dynamodb.AttributeValue{
-		"thing": &dynamodb.AttributeValue{
+		"thing": {
 			N: &thing,
 		},
 	}

--- a/put_test.go
+++ b/put_test.go
@@ -47,7 +47,7 @@ func TestPut(t *testing.T) {
 		},
 		List: []*string{aws.String("abc"), aws.String(""), aws.String("def"), nil, aws.String("ghi")},
 		Set1: []string{"A", "B", ""},
-		Set2: map[string]struct{}{"C": struct{}{}, "D": struct{}{}, "": struct{}{}},
+		Set2: map[string]struct{}{"C": {}, "D": {}, "": {}},
 		Map1: map[string]string{"A": "hello", "B": ""},
 		Map2: map[string]*string{"C": aws.String("world"), "D": nil, "E": aws.String("")},
 	}

--- a/query.go
+++ b/query.go
@@ -495,7 +495,7 @@ func (q *Query) queryInput() *dynamodb.QueryInput {
 
 func (q *Query) keyConditions() map[string]*dynamodb.Condition {
 	conds := map[string]*dynamodb.Condition{
-		q.hashKey: &dynamodb.Condition{
+		q.hashKey: {
 			AttributeValueList: []*dynamodb.AttributeValue{q.hashValue},
 			ComparisonOperator: aws.String(string(Equal)),
 		},

--- a/query_test.go
+++ b/query_test.go
@@ -114,7 +114,6 @@ func TestGetAllCount(t *testing.T) {
 	if !reflect.DeepEqual(one, projected) {
 		t.Errorf("bad result for get one+project. %v ≠ %v", one, projected)
 	}
-
 }
 
 func TestQueryPaging(t *testing.T) {

--- a/table_test.go
+++ b/table_test.go
@@ -17,14 +17,14 @@ func TestAddConsumedCapacity(t *testing.T) {
 			WriteCapacityUnits: aws.Float64(5),
 		},
 		GlobalSecondaryIndexes: map[string]*dynamodb.Capacity{
-			"TestGSI": &dynamodb.Capacity{
+			"TestGSI": {
 				CapacityUnits:      aws.Float64(3),
 				ReadCapacityUnits:  aws.Float64(1),
 				WriteCapacityUnits: aws.Float64(2),
 			},
 		},
 		LocalSecondaryIndexes: map[string]*dynamodb.Capacity{
-			"TestLSI": &dynamodb.Capacity{
+			"TestLSI": {
 				CapacityUnits:      aws.Float64(30),
 				ReadCapacityUnits:  aws.Float64(10),
 				WriteCapacityUnits: aws.Float64(20),

--- a/tx_test.go
+++ b/tx_test.go
@@ -1,10 +1,11 @@
 package dynamo
 
 import (
-	"github.com/gofrs/uuid"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/gofrs/uuid"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )

--- a/update_test.go
+++ b/update_test.go
@@ -33,8 +33,8 @@ func TestUpdate(t *testing.T) {
 			},
 		},
 		MySet1: []string{"one", "deleteme"},
-		MySet2: map[string]struct{}{"a": struct{}{}, "b": struct{}{}, "bad1": struct{}{}, "c": struct{}{}, "bad2": struct{}{}},
-		MySet3: map[int64]struct{}{1: struct{}{}, 999: struct{}{}, 2: struct{}{}, 3: struct{}{}, 555: struct{}{}},
+		MySet2: map[string]struct{}{"a": {}, "b": {}, "bad1": {}, "c": {}, "bad2": {}},
+		MySet3: map[int64]struct{}{1: {}, 999: {}, 2: {}, 3: {}, 555: {}},
 	}
 	err := table.Put(item).Run()
 	if err != nil {
@@ -55,7 +55,7 @@ func TestUpdate(t *testing.T) {
 		If("'Msg' = ?", "hello").
 		DeleteFromSet("MySet1", "deleteme").
 		DeleteFromSet("MySet2", []string{"bad1", "bad2"}).
-		DeleteFromSet("MySet3", map[int64]struct{}{999: struct{}{}, 555: struct{}{}}).
+		DeleteFromSet("MySet3", map[int64]struct{}{999: {}, 555: {}}).
 		ConsumedCapacity(&cc).
 		Value(&result)
 	expected := widget2{
@@ -65,13 +65,13 @@ func TestUpdate(t *testing.T) {
 			Msg:    "changed",
 			Count:  1,
 			Meta: map[string]string{
-				"foo": "baz",
+				"foo":  "baz",
 				"keep": "untouched",
 			},
 		},
 		MySet1: []string{"one"},
-		MySet2: map[string]struct{}{"a": struct{}{}, "b": struct{}{}, "c": struct{}{}},
-		MySet3: map[int64]struct{}{1: struct{}{}, 2: struct{}{}, 3: struct{}{}},
+		MySet2: map[string]struct{}{"a": {}, "b": {}, "c": {}},
+		MySet3: map[int64]struct{}{1: {}, 2: {}, 3: {}},
 	}
 	if err != nil {
 		t.Error("unexpected error:", err)


### PR DESCRIPTION
This PR removes many redundant types from composite literals using `gofmt -w -s *.go internal/exprs/*.go`.