### PR TITLE
Remove dead code reported by golangci-lint

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -142,9 +142,3 @@ type SuperComplex []struct {
 		FFF []int `dynamo:",set"`
 	}
 }
-
-func makeSuperComplex() SuperComplex {
-	sc := make(SuperComplex, 2)
-	sc[0].HelpMe.FFF = []int{1, 2, 3}
-	return sc
-}

--- a/encode.go
+++ b/encode.go
@@ -1,7 +1,6 @@
 package dynamo
 
 import (
-	"bytes"
 	"encoding"
 	"fmt"
 	"reflect"
@@ -687,28 +686,4 @@ func isZero(rv reflect.Value) bool {
 	// Compare other types directly:
 	z := reflect.Zero(rv.Type())
 	return rv.Interface() == z.Interface()
-}
-
-// only works for primary key types
-func isAVEqual(a, b *dynamodb.AttributeValue) bool {
-	if a.S != nil {
-		if b.S == nil {
-			return false
-		}
-		return *a.S == *b.S
-	}
-	if a.N != nil {
-		if b.N == nil {
-			return false
-		}
-		// TODO: parse numbers?
-		return *a.N == *b.N
-	}
-	if a.B != nil {
-		if b.B == nil {
-			return false
-		}
-		return bytes.Equal(a.B, b.B)
-	}
-	return false
 }

--- a/query.go
+++ b/query.go
@@ -68,11 +68,7 @@ const (
 	Descending       = false // ScanIndexForward = false
 )
 
-var (
-	selectAllAttributes      = aws.String("ALL_ATTRIBUTES")
-	selectCount              = aws.String("COUNT")
-	selectSpecificAttributes = aws.String("SPECIFIC_ATTRIBUTES")
-)
+var selectCount = aws.String("COUNT")
 
 // Get creates a new request to get an item.
 // Name is the name of the hash key (a.k.a. partition key).


### PR DESCRIPTION
I decided to keep `_TestUpdateTable` due to the comment "TODO: enable this test".

```
updatetable_test.go:8:6: `_TestUpdateTable` is unused (deadcode)
func _TestUpdateTable(t *testing.T) {
     ^
```