### PR TITLE
Replace deprecated session.New with session.NewSession

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ type widget struct {
 
 
 func main() {
-	db := dynamo.New(session.New(), &aws.Config{Region: aws.String("us-west-2")})
+	sess := session.Must(session.NewSession())
+	db := dynamo.New(sess, &aws.Config{Region: aws.String("us-west-2")})
 	table := db.Table("Widgets")
 
 	// put item

--- a/db_test.go
+++ b/db_test.go
@@ -19,7 +19,7 @@ const offlineSkipMsg = "DYNAMO_TEST_REGION not set"
 
 func init() {
 	if region := os.Getenv("DYNAMO_TEST_REGION"); region != "" {
-		testDB = New(session.New(), &aws.Config{
+		testDB = New(session.Must(session.NewSession()), &aws.Config{
 			Region: aws.String(region),
 			// LogLevel: aws.LogLevel(aws.LogDebugWithHTTPBody),
 		})


### PR DESCRIPTION
From the AWS SDK:

```
// Deprecated: Use NewSession functions to create sessions instead. NewSession
// has the same functionality as New except an error can be returned when the
// func is called instead of waiting to receive an error until a request is made.
```