### PR TITLE
Allow endpoints to be specified by environment  `DYNAMO_TEST_ENDPOINT ` variables on testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,22 @@ By default, tests are run in offline mode. Create a table called `TestDB`, with 
 DYNAMO_TEST_REGION=us-west-2 go test github.com/guregu/dynamo/... -cover
  ```
 
+Example of using [aws-cli](https://docs.aws.amazon.com/ja_jp/amazondynamodb/latest/developerguide/Tools.CLI.html) to create a table for testing.
+
+```bash
+aws dynamodb create-table \
+    --table-name TestDB \
+    --attribute-definitions \
+        AttributeName=UserID,AttributeType=N \
+        AttributeName=Time,AttributeType=S \
+    --key-schema \
+        AttributeName=UserID,KeyType=HASH \
+        AttributeName=Time,KeyType=RANGE \
+    --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1 \
+    --region us-west-2 \
+    --endpoint-url http://localhost:8000
+```
+
 If you want to use [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) to run local tests, specify `DYNAMO_TEST_ENDPOINT`.
 
  ```bash

--- a/README.md
+++ b/README.md
@@ -205,6 +205,12 @@ By default, tests are run in offline mode. Create a table called `TestDB`, with 
 DYNAMO_TEST_REGION=us-west-2 go test github.com/guregu/dynamo/... -cover
  ```
 
+If you want to use [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) to run local tests, specify `DYNAMO_TEST_ENDPOINT`.
+
+ ```bash
+DYNAMO_TEST_REGION=us-west-2 DYNAMO_TEST_ENDPOINT=http://localhost:8000 go test github.com/guregu/dynamo/... -cover
+ ```
+
 ### License
 
 BSD 2-Clause

--- a/db_test.go
+++ b/db_test.go
@@ -19,8 +19,13 @@ const offlineSkipMsg = "DYNAMO_TEST_REGION not set"
 
 func init() {
 	if region := os.Getenv("DYNAMO_TEST_REGION"); region != "" {
+		var endpoint *string
+		if testendoint := os.Getenv("DYNAMO_TEST_ENDPOINT"); testendoint != "" {
+			endpoint = aws.String(testendoint)
+		}
 		testDB = New(session.New(), &aws.Config{
-			Region: aws.String(region),
+			Region:   aws.String(region),
+			Endpoint: endpoint,
 			// LogLevel: aws.LogLevel(aws.LogDebugWithHTTPBody),
 		})
 	}


### PR DESCRIPTION
I wanted to send a pull request for this project, but it was difficult to run the test because I don't have an AWS account at my disposal.

So, in order to use [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html), which I always use for local development, in my tests, I set `DYNAMO_TEST_ENDPOINT` as an environment variable so that `aws.Config.Endpoint` would be set during testing. ( 5c44734b0519bb029f07e2c4d507ba6525f5c6e3 )

I also thought it would be useful to have an example of using aws-cli to prepare the tables needed for testing, so I added the command I used at hand to the README as an example. ( 2acf2757ebca6f9cce2c1d9bac31585b171d4760 )