### PR TITLE
Don't error when WriteTx/GetTx has no items.

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -64,6 +64,10 @@ func (tx *GetTx) RunWithContext(ctx aws.Context) error {
 	if err != nil {
 		return err
 	}
+	if len(tx.items) == 0 {
+		// no get items.
+		return nil
+	}
 	var resp *dynamodb.TransactGetItemsOutput
 	err = retry(ctx, func() error {
 		var err error
@@ -251,6 +255,10 @@ func (tx *WriteTx) Run() error {
 func (tx *WriteTx) RunWithContext(ctx aws.Context) error {
 	if tx.err != nil {
 		return tx.err
+	}
+	if len(tx.items) == 0 {
+		// no write items.
+		return nil
 	}
 	input, err := tx.input()
 	if err != nil {

--- a/tx_test.go
+++ b/tx_test.go
@@ -165,10 +165,6 @@ func TestTx(t *testing.T) {
 
 	// empty commit
 	tx = testDB.WriteTx()
-	// For example, I don't want Run to be an error when I want to fetch/update based on a condition and nothing happens.
-	// if somethingCheck {
-	// 	tx.Put(table.Put(widget{UserID: 69, Time: date2}))
-	// }
 	if err = tx.Run(); err != nil {
 		t.Errorf("WtiteTx: empty commit became error: %s", err)
 	}

--- a/tx_test.go
+++ b/tx_test.go
@@ -1,10 +1,11 @@
 package dynamo
 
 import (
-	"github.com/gofrs/uuid"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/gofrs/uuid"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
@@ -88,6 +89,7 @@ func TestTx(t *testing.T) {
 
 	// GetOne
 	getTx := testDB.GetTx()
+	getTx = testDB.GetTx()
 	var record1, record2, record3 widget
 	var cc2 ConsumedCapacity
 	getTx.GetOne(table.Get("UserID", 69).Range("Time", Equal, date1), &record1)
@@ -159,6 +161,20 @@ func TestTx(t *testing.T) {
 		if err.(awserr.Error).Code() != "TransactionCanceledException" {
 			t.Error("unexpected error:", err)
 		}
+	}
+
+	// empty commit
+	tx = testDB.WriteTx()
+	// For example, I don't want Run to be an error when I want to fetch/update based on a condition and nothing happens.
+	// if somethingCheck {
+	// 	tx.Put(table.Put(widget{UserID: 69, Time: date2}))
+	// }
+	if err = tx.Run(); err != nil {
+		t.Errorf("WtiteTx: empty commit became error: %s", err)
+	}
+	getTx = testDB.GetTx()
+	if err = getTx.Run(); err != nil {
+		t.Errorf("GetTx: empty commit became error: %s", err)
 	}
 
 	t.Logf("1: %+v 2: %+v 3: %+v", record1, record2, record3)


### PR DESCRIPTION
For example:
```golang
tx := db.WriteTx()
if conditionA {
    tx.Put(table.Put(itemA))
}
if conditionB {
    tx.Put(table.Put(itemB))
}
if err := tx.Run(); err != nil {
    return err
}
```

There are cases where there is no update target when Run is done in such a pattern, but we would like to avoid getting an error in such cases.

In this pull request, we have made it so that no error will occur.
However, if it is preferable to have an error, we would like to be able to identify it by making it an error such as `ErrNoTxItems`. (Currently, aws-sdk-go returns an error of InvalidParameter).