### PR TITLE
Add SSESpecification option to CreateTable

### DIFF
--- a/createtable.go
+++ b/createtable.go
@@ -218,12 +218,12 @@ func (ct *CreateTable) Tag(key, value string) *CreateTable {
 }
 
 // SSEEncryption specifies the server side encryption for this table.
-// Encryption is disabled by default. The valid values for sseType are {AES256, KMS}.
-func (ct *CreateTable) SSEEncryption(enabled bool, keyID, sseType string) *CreateTable {
+// Encryption is disabled by default.
+func (ct *CreateTable) SSEEncryption(enabled bool, keyID string, sseType SSEType) *CreateTable {
 	encryption := &dynamodb.SSESpecification{
 		Enabled:        aws.Bool(enabled),
 		KMSMasterKeyId: aws.String(keyID),
-		SSEType:        aws.String(sseType),
+		SSEType:        aws.String(string(sseType)),
 	}
 	ct.encryptionSpecification = encryption
 	return ct

--- a/createtable_test.go
+++ b/createtable_test.go
@@ -46,6 +46,7 @@ func TestCreateTable(t *testing.T) {
 		ProvisionIndex("Embedded-index", 1, 2).
 		Tag("Tag-Key", "old value").
 		Tag("Tag-Key", "Tag-Value").
+		SSEEncryption(true, "alias/key", "KMS").
 		input()
 
 	expected := &dynamodb.CreateTableInput{
@@ -111,6 +112,11 @@ func TestCreateTable(t *testing.T) {
 				Key:   aws.String("Tag-Key"),
 				Value: aws.String("Tag-Value"),
 			},
+		},
+		SSESpecification: &dynamodb.SSESpecification{
+			Enabled:        aws.Bool(true),
+			KMSMasterKeyId: aws.String("alias/key"),
+			SSEType:        aws.String("KMS"),
 		},
 		TableName: aws.String("UserActions"),
 	}

--- a/createtable_test.go
+++ b/createtable_test.go
@@ -46,7 +46,7 @@ func TestCreateTable(t *testing.T) {
 		ProvisionIndex("Embedded-index", 1, 2).
 		Tag("Tag-Key", "old value").
 		Tag("Tag-Key", "Tag-Value").
-		SSEEncryption(true, "alias/key", "KMS").
+		SSEEncryption(true, "alias/key", SSETypeKMS).
 		input()
 
 	expected := &dynamodb.CreateTableInput{

--- a/describetable.go
+++ b/describetable.go
@@ -40,6 +40,8 @@ type Description struct {
 	StreamView        StreamView
 	LatestStreamARN   string
 	LatestStreamLabel string
+
+	SSEDescription SSEDescription
 }
 
 func (d Description) Active() bool {
@@ -183,6 +185,23 @@ func newDescription(table *dynamodb.TableDescription) Description {
 	}
 	if table.LatestStreamLabel != nil {
 		desc.LatestStreamLabel = *table.LatestStreamLabel
+	}
+
+	if table.SSEDescription != nil {
+		sseDesc := SSEDescription{}
+		if table.SSEDescription.InaccessibleEncryptionDateTime != nil {
+			sseDesc.InaccessibleEncryptionDateTime = *table.SSEDescription.InaccessibleEncryptionDateTime
+		}
+		if table.SSEDescription.KMSMasterKeyArn != nil {
+			sseDesc.KMSMasterKeyArn = *table.SSEDescription.KMSMasterKeyArn
+		}
+		if table.SSEDescription.SSEType != nil {
+			sseDesc.SSEType = lookupSSEType(*table.SSEDescription.SSEType)
+		}
+		if table.SSEDescription.Status != nil {
+			sseDesc.Status = *table.SSEDescription.Status
+		}
+		desc.SSEDescription = sseDesc
 	}
 
 	return desc

--- a/sse.go
+++ b/sse.go
@@ -1,0 +1,30 @@
+package dynamo
+
+import "time"
+
+// SSEType is used to specify the type of server side encryption
+// to use on a table
+type SSEType string
+
+// Possible SSE types for tables
+const (
+	SSETypeAES256 SSEType = "AES256"
+	SSETypeKMS    SSEType = "KMS"
+)
+
+type SSEDescription struct {
+	InaccessibleEncryptionDateTime time.Time
+	KMSMasterKeyArn                string
+	SSEType                        SSEType
+	Status                         string
+}
+
+func lookupSSEType(sseType string) SSEType {
+	if sseType == string(SSETypeAES256) {
+		return SSETypeAES256
+	}
+	if sseType == string(SSETypeKMS) {
+		return SSETypeKMS
+	}
+	return ""
+}


### PR DESCRIPTION
Add the option to set the SSESpecification field when creating a table. 


AWS reference: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_SSESpecification.html