### PR TITLE
lazier LEK inference

### DIFF
--- a/db.go
+++ b/db.go
@@ -13,24 +13,37 @@ import (
 // DB is a DynamoDB client.
 type DB struct {
 	client dynamodbiface.DynamoDBAPI
+	logger aws.Logger
 }
 
 // New creates a new client with the given configuration.
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *DB {
+	cfg := p.ClientConfig(dynamodb.EndpointsID, cfgs...)
 	db := &DB{
-		dynamodb.New(p, cfgs...),
+		client: dynamodb.New(p, cfgs...),
+		logger: cfg.Config.Logger,
+	}
+	if db.logger == nil {
+		db.logger = aws.NewDefaultLogger()
 	}
 	return db
 }
 
 // NewFromIface creates a new client with the given interface.
 func NewFromIface(client dynamodbiface.DynamoDBAPI) *DB {
-	return &DB{client}
+	return &DB{
+		client: client,
+		logger: aws.NewDefaultLogger(),
+	}
 }
 
 // Client returns this DB's internal client used to make API requests.
 func (db *DB) Client() dynamodbiface.DynamoDBAPI {
 	return db.client
+}
+
+func (db *DB) log(v ...interface{}) {
+	db.logger.Log(v...)
 }
 
 // ListTables is a request to list tables.

--- a/query.go
+++ b/query.go
@@ -2,7 +2,6 @@ package dynamo
 
 import (
 	"errors"
-	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -313,8 +312,10 @@ type queryIter struct {
 	last map[string]*dynamodb.AttributeValue
 	// cache of primary keys, used for generating LEKs
 	keys map[string]struct{}
-	// we don't need to worry about inferring the LEK if users can't access it
-	skipLEK bool
+	// example LastEvaluatedKey and ExclusiveStartKey, used to lazily evaluate the primary keys if possible
+	exLEK  map[string]*dynamodb.AttributeValue
+	exESK  map[string]*dynamodb.AttributeValue
+	keyErr error
 
 	unmarshal unmarshalFunc
 }
@@ -338,6 +339,8 @@ func (itr *queryIter) NextWithContext(ctx aws.Context, out interface{}) bool {
 
 	// stop if exceed limit
 	if itr.query.limit > 0 && itr.n == itr.query.limit {
+		// proactively grab the keys for LEK inferral, but don't count it as a real error yet to keep backwards compat
+		itr.keys, itr.keyErr = itr.query.table.primaryKeys(ctx, itr.exLEK, itr.exESK, itr.query.index)
 		return false
 	}
 
@@ -354,6 +357,9 @@ func (itr *queryIter) NextWithContext(ctx aws.Context, out interface{}) bool {
 	// new query
 	if itr.input == nil {
 		itr.input = itr.query.queryInput()
+	}
+	if len(itr.input.ExclusiveStartKey) > len(itr.exESK) {
+		itr.exESK = itr.input.ExclusiveStartKey
 	}
 	if itr.output != nil && itr.idx >= len(itr.output.Items) {
 		// have we exhausted all results?
@@ -378,12 +384,8 @@ func (itr *queryIter) NextWithContext(ctx aws.Context, out interface{}) bool {
 	if itr.query.cc != nil {
 		addConsumedCapacity(itr.query.cc, itr.output.ConsumedCapacity)
 	}
-
-	if !itr.skipLEK && itr.keys == nil {
-		itr.keys, itr.err = itr.query.table.primaryKeys(ctx, itr.output.LastEvaluatedKey, itr.input.ExclusiveStartKey, itr.query.index)
-		if itr.err != nil {
-			return false
-		}
+	if len(itr.output.LastEvaluatedKey) > len(itr.exLEK) {
+		itr.exLEK = itr.output.LastEvaluatedKey
 	}
 
 	if len(itr.output.Items) == 0 {
@@ -415,13 +417,28 @@ func (itr *queryIter) LastEvaluatedKey() PagingKey {
 		if itr.idx == len(itr.output.Items) {
 			return itr.output.LastEvaluatedKey
 		}
-		// otherwise, we need to infer the LEK from the last item we saw
+
+		// figure out the primary keys if needed
+		if itr.keys == nil && itr.keyErr == nil {
+			ctx, _ := defaultContext() // TODO(v2): take context instead of using the default
+			itr.keys, itr.keyErr = itr.query.table.primaryKeys(ctx, itr.exLEK, itr.exESK, itr.query.index)
+		}
+		if itr.keyErr != nil {
+			// primaryKeys can fail if the credentials lack DescribeTable permissions
+			// in order to preserve backwards compatibility, we fall back to the old behavior and warn
+			// see: https://github.com/guregu/dynamo/pull/187#issuecomment-1045183901
+			// TODO(v2): rejigger this API.
+			itr.query.table.db.log("dynamo: Warning:", itr.keyErr, "Returning a later LastEvaluatedKey.")
+			return itr.output.LastEvaluatedKey
+		}
+
+		// we can't use the real LEK, so we need to infer the LEK from the last item we saw
 		lek, err := lekify(itr.last, itr.keys)
 		// unfortunately, this API can't return an error so a warning is the best we can do...
 		// this matches old behavior before the LEK was automatically generated
 		// TODO(v2): fix this.
 		if err != nil {
-			log.Println("Warning:", err, "Returning a later LastEvaluatedKey.")
+			itr.query.table.db.log("dynamo: Warning:", err, "Returning a later LastEvaluatedKey.")
 			return itr.output.LastEvaluatedKey
 		}
 		return lek
@@ -441,7 +458,6 @@ func (q *Query) AllWithContext(ctx aws.Context, out interface{}) error {
 		query:     q,
 		unmarshal: unmarshalAppend,
 		err:       q.err,
-		skipLEK:   true,
 	}
 	for iter.NextWithContext(ctx, out) {
 	}


### PR DESCRIPTION
- delay LEK inference's primary key retrieval as much as possible, avoiding DescribeTable in more circumstances
- to preserve backwards compatibility, don't fail but warn when we can't DescribeTable
  - see: https://github.com/guregu/dynamo/pull/187#issuecomment-1045183901
- use aws.Config's logger for warning messages

Definitely want to change these interfaces for #113.