### PR TITLE
add ExpressionLiteral for passing in raw expressions and placeholders

### DIFF
--- a/decode_aux_test.go
+++ b/decode_aux_test.go
@@ -35,7 +35,7 @@ func TestEncodingAux(t *testing.T) {
 		name string
 		out  interface{}
 	}{
-		{name: "no custom unmrashalling", out: coffeeItemDefault{ID: "intenso", Coffee: Coffee{Name: "Intenso 12"}}},
+		{name: "no custom unmarshalling", out: coffeeItemDefault{ID: "intenso", Coffee: Coffee{Name: "Intenso 12"}}},
 		{name: "AWS SDK pointer", out: coffeeItemSDKEmbeddedPointer{ID: "intenso", Coffee: &Coffee{Name: "Intenso 12"}}},
 		{name: "flat", out: coffeeItemFlat{ID: "intenso", Name: "Intenso 12"}},
 		{name: "flat (invalid)", out: coffeeItemInvalid{}}, // want to make sure this doesn't panic


### PR DESCRIPTION
This adds a new type called `ExpressionLiteral`, which allows you to pass raw DynamoDB expressions to any method that takes an expression. dynamo will merge your placeholders with its own, rewriting your expression a little bit to avoid clobbering our automatically generated placeholders.
You can use either `$` or `?` as the variable when passing this as an argument to functions like `FilterExpr`.
Be careful with this, especially if you use it with Update or for conditional writes. Improper usage could open yourself up to injection attacks. I definitely do not recommend that. Think of this like using string concatenation to build SQL.

One of the major features of this library is abstracting placeholder management away from you. My hope is that most people won't have to use this, but it can be useful for certain things. 
You can use this along with AWS's [expression](https://docs.aws.amazon.com/sdk-for-go/api/service/dynamodb/expression/) library. This is helpful for people who want to move from the official AWS SDK to ours, or vice-versa. Perhaps we will want to support this passing in objects from this package explicitly later on, but for now it's easy to convert between the two. 
Another use case would be if you wanted to take DynamoDB expressions as user input for implementing search parameters. Why not take advantage of the [JS library](https://www.npmjs.com/package/@aws/dynamodb-expressions)? 🤠