### PR TITLE
Adding allowemptyelem support for nested maps and slices

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -285,7 +285,10 @@ func marshalReflect(rv reflect.Value, flags encodeFlags) (*dynamodb.AttributeVal
 		avs := make(map[string]*dynamodb.AttributeValue)
 		subflags := flagNone
 		if flags&flagAllowEmptyElem != 0 {
-			subflags |= flagAllowEmpty | flagNull | flagAllowEmptyElem
+			subflags |= flagAllowEmpty | flagNull
+			// child containers of a map also have the allowEmptyElem behavior
+			// i.e. lists inside a map or maps inside a map
+			subflags |= flagAllowEmptyElem
 		} else if flags&flagOmitEmptyElem != 0 {
 			subflags |= flagOmitEmpty
 		}
@@ -356,6 +359,8 @@ func marshalReflect(rv reflect.Value, flags encodeFlags) (*dynamodb.AttributeVal
 			subflags |= flagAllowEmpty | flagNull
 		}
 		if flags&flagAllowEmptyElem != 0 {
+			// child containers of a list also have the allowEmptyElem behavior
+			// e.g. maps inside a list
 			subflags |= flagAllowEmptyElem
 		}
 		for i := 0; i < rv.Len(); i++ {

--- a/encode.go
+++ b/encode.go
@@ -285,7 +285,7 @@ func marshalReflect(rv reflect.Value, flags encodeFlags) (*dynamodb.AttributeVal
 		avs := make(map[string]*dynamodb.AttributeValue)
 		subflags := flagNone
 		if flags&flagAllowEmptyElem != 0 {
-			subflags |= flagAllowEmpty | flagNull
+			subflags |= flagAllowEmpty | flagNull | flagAllowEmptyElem
 		} else if flags&flagOmitEmptyElem != 0 {
 			subflags |= flagOmitEmpty
 		}
@@ -354,6 +354,9 @@ func marshalReflect(rv reflect.Value, flags encodeFlags) (*dynamodb.AttributeVal
 			// unless "omitemptyelem" flag is set, include empty/null values
 			// this will preserve the position of items in the list
 			subflags |= flagAllowEmpty | flagNull
+		}
+		if flags&flagAllowEmptyElem != 0 {
+			subflags |= flagAllowEmptyElem
 		}
 		for i := 0; i < rv.Len(); i++ {
 			innerVal := rv.Index(i)

--- a/encode_test.go
+++ b/encode_test.go
@@ -48,6 +48,31 @@ var itemEncodeOnlyTests = []struct {
 		},
 	},
 	{
+		name: "allowemptyelem flag on map with a struct element that has a map field",
+		in: struct {
+			M map[string]interface{} `dynamo:",allowemptyelem"`
+		}{
+			M: map[string]interface{}{
+				"struct": struct {
+					InnerMap map[string]interface{} // no struct tags, empty elems not encoded
+				}{
+					InnerMap: map[string]interface{}{
+						"empty": "",
+					},
+				},
+			},
+		},
+		out: map[string]*dynamodb.AttributeValue{
+			"M": {M: map[string]*dynamodb.AttributeValue{
+				"struct": {M: map[string]*dynamodb.AttributeValue{
+					"InnerMap": {M: map[string]*dynamodb.AttributeValue{
+						// expected empty inside
+					}},
+				}},
+			}},
+		},
+	},
+	{
 		name: "unexported field",
 		in: struct {
 			Public   int

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -373,6 +373,68 @@ var itemEncodingTests = []struct {
 		},
 	},
 	{
+		name: "allowemptyelem flag on map with map element",
+		in: struct {
+			M map[string]interface{} `dynamo:",allowemptyelem"`
+		}{
+			M: map[string]interface{}{
+				"nestedmap": map[string]interface{}{
+					"empty": "",
+				},
+			},
+		},
+		out: map[string]*dynamodb.AttributeValue{
+			"M": {M: map[string]*dynamodb.AttributeValue{
+				"nestedmap": {M: map[string]*dynamodb.AttributeValue{
+					"empty": {S: aws.String("")},
+				}},
+			}},
+		},
+	},
+	{
+		name: "allowemptyelem flag on map with slice element, which has a map element",
+		in: struct {
+			M map[string]interface{} `dynamo:",allowemptyelem"`
+		}{
+			M: map[string]interface{}{
+				"slice": []interface{}{
+					map[string]interface{}{"empty": ""},
+				},
+			},
+		},
+		out: map[string]*dynamodb.AttributeValue{
+			"M": {M: map[string]*dynamodb.AttributeValue{
+				"slice": {L: []*dynamodb.AttributeValue{
+					{M: map[string]*dynamodb.AttributeValue{
+						"empty": {S: aws.String("")},
+					}},
+				}},
+			}},
+		},
+	},
+	{
+		name: "allowemptyelem flag on slice with map element",
+		in: struct {
+			L []interface{} `dynamo:",allowemptyelem"`
+		}{
+			L: []interface{}{
+				map[string]interface{}{
+					"empty": "",
+				},
+			},
+		},
+		out: map[string]*dynamodb.AttributeValue{
+			"L": {L: []*dynamodb.AttributeValue{
+				{
+					M: map[string]*dynamodb.AttributeValue{
+						"empty": {S: aws.String("")},
+					},
+				},
+			},
+			},
+		},
+	},
+	{
 		name: "null flag",
 		in: struct {
 			S       string             `dynamo:",null"`


### PR DESCRIPTION
Fixes https://github.com/guregu/dynamo/issues/199

Currently, the allowemptyelem flags only applies to the first level elements of a map, however it would be useful to have this behaviour cascade down to nested maps as well.

The change is mostly to forward flagAllowEmptyElem in marshalling cases for any containers except structs.

I took a stab at what a reasonable behaviour of this should be, but open to alternate suggestions.

- map fields that have this flag will push it down, so maps of maps of maps of strings will allow empty strings, etc
- slices also perpetuate this behaviour down, since there could be []map[string]interface{} and so forth
- structs do not have this behaviour, since all of its fields have explicit tagging (or the absence of). it would be a bit of a surprise that a map field inside a struct suddenly allows empty elems even though that field does not specify it

Alternatives I've considered:
- have structs also forward this flag down. this can be convenient in that generally one would marshal an object tree with the same semantics (e.g. empty strings allowed everywhere) but has the issue of the slightly surprising behaviour mentioned above. both options are a little unintuitive imo
- only forward the flag through chains of maps, and not include slices. this would scope the fix but I believe this to be painful for devs pretty quickly when they marshal an object and it marshals differently depending on their container ancestry
- don't fix this via struct tags, but allow this via some other mechanism. this would be a much bigger change and fragment the API a bit so I wasn't a fan