### PR TITLE
Remove `github.com/gofrs/uuid` as a dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/guregu/dynamo
 require (
 	github.com/aws/aws-sdk-go v1.44.185
 	github.com/cenkalti/backoff/v4 v4.1.2
-	github.com/gofrs/uuid v4.2.0+incompatible
 	golang.org/x/net v0.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/cenkalti/backoff/v4 v4.1.2 h1:6Yo7N8UP2K6LWZnW94DLVSSrbobcWdVzAYOisuD
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
-github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/tx_test.go
+++ b/tx_test.go
@@ -179,6 +179,10 @@ func TestTx(t *testing.T) {
 }
 
 func TestTxRetry(t *testing.T) {
+	if testDB == nil {
+		t.Skip(offlineSkipMsg)
+	}
+
 	date1 := time.Date(1999, 1, 1, 1, 1, 1, 0, time.UTC)
 	widget1 := widget{UserID: 69, Time: date1, Msg: "dog", Count: 0}
 

--- a/tx_test.go
+++ b/tx_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofrs/uuid"
-
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
@@ -57,11 +55,11 @@ func TestTx(t *testing.T) {
 	// idempotent write with provided idempotency token
 	tx = testDB.WriteTx()
 	cc, ccold = ConsumedCapacity{}, ConsumedCapacity{}
-	token, err := uuid.NewV4()
+	token, err := newIdempotencyToken()
 	if err != nil {
 		t.Error(err)
 	}
-	tx.IdempotentWithToken(token.String())
+	tx.IdempotentWithToken(token)
 	tx.Put(table.Put(widget1))
 	tx.Put(table.Put(widget2))
 	tx.ConsumedCapacity(&cc)


### PR DESCRIPTION
Recently, I was puzzled why `github.com/gofrs/uuid` was included when updating the vendored dependencies in another project. The reason for its inclusion lead to this project. As it turns out, it was introduced by #84 only to generate a [ClientRequestToken](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html#DDB-TransactWriteItems-request-ClientRequestToken) for the purpose of idempotent transactions.

This proposes to generate the default token with [`crypto/rand.Reader`](https://pkg.go.dev/crypto/rand#pkg-variables) instead.

This is equivalent to a Version 4 UUID except we gain an additional 6 bits of entropy. The main advantage is that this removes the only reason for importing then entire `github.com/gofrs/uuid` making for fewer dependencies for downstream consumers.