### PR TITLE
Fix to reassign loop variable

### DIFF
--- a/createtable.go
+++ b/createtable.go
@@ -129,6 +129,7 @@ func (ct *CreateTable) Project(index string, projection IndexProjection, include
 	if projection == IncludeProjection {
 	attribs:
 		for _, attr := range includeAttribs {
+			attr := attr
 			for _, a := range proj.NonKeyAttributes {
 				if attr == *a {
 					continue attribs

--- a/createtable_test.go
+++ b/createtable_test.go
@@ -15,6 +15,7 @@ type UserAction struct {
 	Time   time.Time `dynamo:",range"`
 	Seq    int64     `localIndex:"ID-Seq-index,range"`
 	UUID   string
+	Name   string
 	embeddedWithKeys
 }
 
@@ -41,7 +42,7 @@ func TestCreateTable(t *testing.T) {
 	// }
 
 	input := testDB.CreateTable("UserActions", UserAction{}).
-		Project("ID-Seq-index", IncludeProjection, "UUID").
+		Project("ID-Seq-index", IncludeProjection, "UUID", "Name").
 		Provision(4, 2).
 		ProvisionIndex("Embedded-index", 1, 2).
 		Tag("Tag-Key", "old value").
@@ -100,7 +101,7 @@ func TestCreateTable(t *testing.T) {
 			}},
 			Projection: &dynamodb.Projection{
 				ProjectionType:   aws.String("INCLUDE"),
-				NonKeyAttributes: []*string{aws.String("UUID")},
+				NonKeyAttributes: []*string{aws.String("UUID"), aws.String("Name")},
 			},
 		}},
 		ProvisionedThroughput: &dynamodb.ProvisionedThroughput{


### PR DESCRIPTION
Even if `includeAttribs` had multiple elements, only the last value would be registered.
"proj.NonKeyAttributes" was storing the pointer of the loop variable as it was, so I reassigned "attr" in the loop and modified it to store a different pointer for each element.