### PR TITLE
Add Parallel Scanning support 

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -20,6 +20,9 @@ type Scan struct {
 	limit       int64
 	searchLimit int64
 
+	segment       int64
+	totalSegments int64
+
 	subber
 
 	err error
@@ -43,6 +46,13 @@ func (s *Scan) StartFrom(key PagingKey) *Scan {
 // Index specifies the name of the index that Scan will operate on.
 func (s *Scan) Index(name string) *Scan {
 	s.index = name
+	return s
+}
+
+// Parallel specifies the Segment and Total Segments to operate on in a parallel scan.
+func (s *Scan) Parallel(segment int64, totalSegments int64) *Scan {
+	s.segment = segment
+	s.totalSegments = totalSegments
 	return s
 }
 
@@ -203,6 +213,10 @@ func (s *Scan) scanInput() *dynamodb.ScanInput {
 		ConsistentRead:            &s.consistent,
 		ExpressionAttributeNames:  s.nameExpr,
 		ExpressionAttributeValues: s.valueExpr,
+	}
+	if s.totalSegments > 0 {
+		input.Segment = &s.segment
+		input.TotalSegments = &s.totalSegments
 	}
 	if s.limit > 0 {
 		if len(s.filters) == 0 {


### PR DESCRIPTION
- Upstream Docs: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan

- This PR adds a simple setter for the Segments and TotalSegments fields.  They should only be set together, so the `Parallel(segment int64, totalSegments int64)` function signature made sense to me.

- A higher level interface that also sets these values (eg multiple goroutines) might be helpful as another layer -- but this is the minimal change to be able to use the existing Scan() interface with a parallel scan -- and in my use case different segments are being processed by different containers, so a goroutine layer wouldn't' be helpful.