### PR TITLE
Add parallel scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ type widget struct {
 
 	Msg       string              `dynamo:"Message"`    // Change name in the database
 	Count     int                 `dynamo:",omitempty"` // Omits if zero value
-	Children  []widget            // Lists
+	Children  []widget            // List of maps
 	Friends   []string            `dynamo:",set"` // Sets
 	Set       map[string]struct{} `dynamo:",set"` // Map sets, too!
 	SecretKey string              `dynamo:"-"`    // Ignored

--- a/db.go
+++ b/db.go
@@ -177,6 +177,7 @@ type PagingIter interface {
 	LastEvaluatedKey() PagingKey
 }
 
+// PagingIter is an iterator of combined request results from multiple iterators running in parallel.
 type ParallelIter interface {
 	Iter
 	// LastEvaluatedKeys returns each parallel segment's last evaluated key in order of segment number.

--- a/db.go
+++ b/db.go
@@ -177,6 +177,13 @@ type PagingIter interface {
 	LastEvaluatedKey() PagingKey
 }
 
+type ParallelIter interface {
+	Iter
+	// LastEvaluatedKeys returns each parallel segment's last evaluated key in order of segment number.
+	// The slice will be the same size as the number of segments, and the keys can be nil.
+	LastEvaluatedKeys() []PagingKey
+}
+
 // PagingKey is a key used for splitting up partial results.
 // Get a PagingKey from a PagingIter and pass it to StartFrom in Query or Scan.
 type PagingKey map[string]*dynamodb.AttributeValue

--- a/db_test.go
+++ b/db_test.go
@@ -35,8 +35,8 @@ func init() {
 
 // widget is the data structure used for integration tests
 type widget struct {
-	UserID int       // PK
-	Time   time.Time // RK
+	UserID int       `dynamo:",hash"`
+	Time   time.Time `dynamo:",range"`
 	Msg    string
 	Count  int
 	Meta   map[string]string

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.223
 	github.com/cenkalti/backoff/v4 v4.2.0
 	golang.org/x/net v0.7.0 // indirect
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
-github.com/aws/aws-sdk-go v1.44.201 h1:gKtyFyiVGh/uTW7sCQaoyU6XCUsnI8+WWKmbEaABCfw=
-github.com/aws/aws-sdk-go v1.44.201/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go v1.44.223 h1:8FiGnB6W3WO5R0iCGuW2E0pgdunN37jtNcoHJ7tSa98=
 github.com/aws/aws-sdk-go v1.44.223/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/cenkalti/backoff/v4 v4.1.2 h1:6Yo7N8UP2K6LWZnW94DLVSSrbobcWdVzAYOisuDPIFo=
-github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=
 github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
@@ -27,6 +23,7 @@ golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/net v0.7.0 h1:rJrUqqhjsgNp7KqAIc25s9pZnjU7TUcSY7HcVZjdn1g=
 golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/scan.go
+++ b/scan.go
@@ -1,10 +1,13 @@
 package dynamo
 
 import (
+	"context"
 	"strings"
+	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"golang.org/x/sync/errgroup"
 )
 
 // Scan is a request to scan all the data in a table.
@@ -38,6 +41,7 @@ func (table Table) Scan() *Scan {
 
 // StartFrom makes this scan continue from a previous one.
 // Use Scan.Iter's LastEvaluatedKey.
+// Ignored by ParallelIter and friends, pass multiple keys to ParallelIterStartFrom instead.
 func (s *Scan) StartFrom(key PagingKey) *Scan {
 	s.startKey = key
 	return s
@@ -49,11 +53,37 @@ func (s *Scan) Index(name string) *Scan {
 	return s
 }
 
-// Segment specifies the Segment and Total Segments to operate on in a parallel scan.
+// Segment specifies the Segment and Total Segments to operate on in a manual parallel scan.
+// This is useful if you want to control the parallel scans by yourself instead of using ParallelIter.
+// Ignored by ParallelIter and friends.
 func (s *Scan) Segment(segment int64, totalSegments int64) *Scan {
 	s.segment = segment
 	s.totalSegments = totalSegments
 	return s
+}
+
+func (s *Scan) newSegments(segments int64, leks []PagingKey) []*scanIter {
+	iters := make([]*scanIter, segments)
+	lekLen := int64(len(leks))
+	for i := int64(0); i < segments; i++ {
+		seg := *s
+		var cc *ConsumedCapacity
+		if s.cc != nil {
+			cc = new(ConsumedCapacity)
+		}
+		seg.Segment(i, segments).ConsumedCapacity(cc)
+		if i < lekLen {
+			lek := leks[i]
+			if lek == nil {
+				continue
+			}
+			seg.StartFrom(leks[i])
+		} else {
+			seg.StartFrom(nil)
+		}
+		iters[i] = seg.Iter().(*scanIter)
+	}
+	return iters
 }
 
 // Project limits the result attributes to the given paths.
@@ -113,12 +143,29 @@ func (s *Scan) Iter() PagingIter {
 	}
 }
 
+// IterParallel returns a results iterator for this request, running the given number of segments in parallel.
+// Canceling the context given here will cancel the processing of all segments.
+func (s *Scan) IterParallel(ctx context.Context, segments int64) ParallelIter {
+	iters := s.newSegments(segments, nil)
+	ps := newParallelScan(iters, s.cc, false, unmarshalItem)
+	go ps.run(ctx)
+	return ps
+}
+
+// IterParallelFrom returns a results iterator continued from a previous ParallelIter's LastEvaluatedKeys.
+// Canceling the context given here will cancel the processing of all segments.
+func (s *Scan) IterParallelStartFrom(ctx context.Context, keys []PagingKey) ParallelIter {
+	iters := s.newSegments(int64(len(keys)), keys)
+	ps := newParallelScan(iters, s.cc, false, unmarshalItem)
+	go ps.run(ctx)
+	return ps
+}
+
 // All executes this request and unmarshals all results to out, which must be a pointer to a slice.
 func (s *Scan) All(out interface{}) error {
 	ctx, cancel := defaultContext()
 	defer cancel()
-	_, err := s.AllWithLastEvaluatedKeyContext(ctx, out)
-	return err
+	return s.AllWithContext(ctx, out)
 }
 
 // AllWithContext executes this request and unmarshals all results to out, which must be a pointer to a slice.
@@ -152,6 +199,31 @@ func (s *Scan) AllWithLastEvaluatedKeyContext(ctx aws.Context, out interface{}) 
 	for itr.NextWithContext(ctx, out) {
 	}
 	return itr.LastEvaluatedKey(), itr.Err()
+}
+
+// AllParallel executes this request by running the given number of segments in parallel, then unmarshaling all results to out, which must be a pointer to a slice.
+func (s *Scan) AllParallel(ctx aws.Context, segments int64, out interface{}) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	iters := s.newSegments(segments, nil)
+	ps := newParallelScan(iters, s.cc, true, unmarshalAppend)
+	go ps.run(ctx)
+	for ps.NextWithContext(ctx, out) {
+	}
+	return ps.Err()
+}
+
+// AllParallelStartFrom executes this request by continuing parallel scans from the given LastEvaluatedKeys, then unmarshaling all results to out, which must be a pointer to a slice.
+// Returns a new slice of LastEvaluatedKeys after the scan finishes.
+func (s *Scan) AllParallelStartFrom(ctx aws.Context, keys []PagingKey, out interface{}) ([]PagingKey, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	iters := s.newSegments(int64(len(keys)), keys)
+	ps := newParallelScan(iters, s.cc, false, unmarshalAppend)
+	go ps.run(ctx)
+	for ps.NextWithContext(ctx, out) {
+	}
+	return ps.LastEvaluatedKeys(), ps.Err()
 }
 
 // Count executes this request and returns the number of items matching the scan.
@@ -278,6 +350,7 @@ func (itr *scanIter) Next(out interface{}) bool {
 }
 
 func (itr *scanIter) NextWithContext(ctx aws.Context, out interface{}) bool {
+redo:
 	// stop if we have an error
 	if ctx.Err() != nil {
 		itr.err = ctx.Err()
@@ -339,7 +412,7 @@ func (itr *scanIter) NextWithContext(ctx aws.Context, out interface{}) bool {
 
 	if len(itr.output.Items) == 0 {
 		if itr.output.LastEvaluatedKey != nil {
-			return itr.NextWithContext(ctx, out)
+			goto redo
 		}
 		return false
 	}
@@ -393,4 +466,115 @@ func (itr *scanIter) LastEvaluatedKey() PagingKey {
 		return lek
 	}
 	return nil
+}
+
+type parallelScan struct {
+	iters []*scanIter
+	items chan map[string]*dynamodb.AttributeValue
+
+	leks []PagingKey
+	cc   *ConsumedCapacity
+	err  error
+	mu   *sync.Mutex
+
+	unmarshal unmarshalFunc
+}
+
+func newParallelScan(iters []*scanIter, cc *ConsumedCapacity, skipLEK bool, unmarshal unmarshalFunc) *parallelScan {
+	ps := &parallelScan{
+		iters:     iters,
+		items:     make(chan map[string]*dynamodb.AttributeValue),
+		cc:        cc,
+		mu:        new(sync.Mutex),
+		unmarshal: unmarshal,
+	}
+	if !skipLEK {
+		ps.leks = make([]PagingKey, len(ps.iters))
+	}
+	return ps
+}
+
+func (ps *parallelScan) run(ctx context.Context) {
+	grp, ctx := errgroup.WithContext(ctx)
+	for i, iter := range ps.iters {
+		i, iter := i, iter
+		if iter == nil {
+			continue
+		}
+		grp.Go(func() error {
+			var item map[string]*dynamodb.AttributeValue
+			for iter.NextWithContext(ctx, &item) {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case ps.items <- item:
+				}
+
+				if ps.leks != nil {
+					lek := iter.LastEvaluatedKey()
+					ps.mu.Lock()
+					ps.leks[i] = lek
+					ps.mu.Unlock()
+				}
+			}
+
+			if ps.cc != nil && iter.scan.cc != nil {
+				ps.mu.Lock()
+				mergeConsumedCapacity(ps.cc, iter.scan.cc)
+				ps.mu.Unlock()
+			}
+
+			return iter.Err()
+		})
+	}
+	err := grp.Wait()
+	if err != nil {
+		ps.setError(err)
+	}
+	close(ps.items)
+}
+
+func (ps *parallelScan) Next(out interface{}) bool {
+	ctx, cancel := defaultContext()
+	defer cancel()
+	return ps.NextWithContext(ctx, out)
+}
+
+func (ps *parallelScan) NextWithContext(ctx context.Context, out interface{}) bool {
+	select {
+	case <-ctx.Done():
+		ps.setError(ctx.Err())
+		return false
+	case item := <-ps.items:
+		if item == nil {
+			return false
+		}
+		if err := ps.unmarshal(item, out); err != nil {
+			ps.setError(err)
+			return false
+		}
+		return true
+	}
+}
+
+func (ps *parallelScan) setError(err error) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	if ps.err == nil {
+		ps.err = err
+	}
+}
+
+func (ps *parallelScan) Err() error {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	return ps.err
+}
+
+func (ps *parallelScan) LastEvaluatedKeys() []PagingKey {
+	keys := make([]PagingKey, len(ps.leks))
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	copy(keys, ps.leks)
+	return keys
 }

--- a/scan_test.go
+++ b/scan_test.go
@@ -135,6 +135,11 @@ func TestScanPaging(t *testing.T) {
 			}
 			itr = table.Scan().StartFrom(itr.LastEvaluatedKey()).SearchLimit(1).Iter()
 		}
+		for i, w := range widgets {
+			if w.Time.IsZero() {
+				t.Error("scan didn't find item", i)
+			}
+		}
 	})
 
 	t.Run("parallel", func(t *testing.T) {
@@ -157,6 +162,11 @@ func TestScanPaging(t *testing.T) {
 				break
 			}
 			itr = table.Scan().SearchLimit(1).IterParallelStartFrom(ctx, itr.LastEvaluatedKeys())
+		}
+		for i, w := range widgets {
+			if w.Time.IsZero() {
+				t.Error("scan didn't find item", i)
+			}
 		}
 	})
 }

--- a/table.go
+++ b/table.go
@@ -100,9 +100,9 @@ func (table Table) WaitWithContext(ctx aws.Context, want ...Status) error {
 
 // primaryKeys attempts to determine this table's primary keys.
 // It will try:
-// - output LastEvaluatedKey
-// - input ExclusiveStartKey
-// - DescribeTable as a last resort (cached inside table)
+//   - output LastEvaluatedKey
+//   - input ExclusiveStartKey
+//   - DescribeTable as a last resort (cached inside table)
 func (table Table) primaryKeys(ctx aws.Context, lek, esk map[string]*dynamodb.AttributeValue, index string) (map[string]struct{}, error) {
 	extract := func(item map[string]*dynamodb.AttributeValue) map[string]struct{} {
 		keys := make(map[string]struct{}, len(item))

--- a/table.go
+++ b/table.go
@@ -322,3 +322,66 @@ func addConsumedCapacity(cc *ConsumedCapacity, raw *dynamodb.ConsumedCapacity) {
 		cc.TableName = *raw.TableName
 	}
 }
+
+func mergeConsumedCapacity(dst, src *ConsumedCapacity) {
+	if dst == nil || src == nil {
+		return
+	}
+	dst.Total += src.Total
+	dst.Read += src.Read
+	dst.Write += src.Write
+	if len(src.GSI) > 0 {
+		if dst.GSI == nil {
+			dst.GSI = make(map[string]float64, len(src.GSI))
+		}
+		for name, consumed := range src.GSI {
+			dst.GSI[name] = dst.GSI[name] + consumed
+		}
+	}
+	if len(src.GSIRead) > 0 {
+		if dst.GSIRead == nil {
+			dst.GSIRead = make(map[string]float64, len(src.GSIRead))
+		}
+		for name, consumed := range src.GSIRead {
+			dst.GSIRead[name] = dst.GSIRead[name] + consumed
+		}
+	}
+	if len(src.GSIWrite) > 0 {
+		if dst.GSIWrite == nil {
+			dst.GSIWrite = make(map[string]float64, len(src.GSIWrite))
+		}
+		for name, consumed := range src.GSIWrite {
+			dst.GSIWrite[name] = dst.GSIWrite[name] + consumed
+		}
+	}
+	if len(src.LSI) > 0 {
+		if dst.LSI == nil {
+			dst.LSI = make(map[string]float64, len(src.LSI))
+		}
+		for name, consumed := range src.LSI {
+			dst.LSI[name] = dst.LSI[name] + consumed
+		}
+	}
+	if len(src.LSIRead) > 0 {
+		if dst.LSIRead == nil {
+			dst.LSIRead = make(map[string]float64, len(src.LSIRead))
+		}
+		for name, consumed := range src.LSIRead {
+			dst.LSIRead[name] = dst.LSIRead[name] + consumed
+		}
+	}
+	if len(src.LSIWrite) > 0 {
+		if dst.LSIWrite == nil {
+			dst.LSIWrite = make(map[string]float64, len(src.LSIWrite))
+		}
+		for name, consumed := range src.LSIWrite {
+			dst.LSIWrite[name] = dst.LSIWrite[name] + consumed
+		}
+	}
+	dst.Table += src.Table
+	dst.TableRead += src.TableRead
+	dst.TableWrite += src.TableWrite
+	if dst.TableName == "" && src.TableName != "" {
+		dst.TableName = src.TableName
+	}
+}


### PR DESCRIPTION
Closes #20. This adds some methods to Scan that uses a parallel iterator to run multiple segments at once, automating the segment handling.
I haven't tested it a bunch yet but it seems to work and is faster than a regular Scan in the tests.