### PR TITLE
Added checks for nil output when adding consumed capacity

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -110,7 +110,7 @@ func (d *Delete) run(ctx context.Context) (*dynamodb.DeleteItemOutput, error) {
 		output, err = d.table.db.client.DeleteItem(ctx, input)
 		return err
 	})
-	if d.cc != nil {
+	if d.cc != nil && output != nil {
 		addConsumedCapacity(d.cc, output.ConsumedCapacity)
 	}
 	return output, err

--- a/put.go
+++ b/put.go
@@ -83,7 +83,7 @@ func (p *Put) run(ctx context.Context) (output *dynamodb.PutItemOutput, err erro
 		output, err = p.table.db.client.PutItem(ctx, req)
 		return err
 	})
-	if p.cc != nil {
+	if p.cc != nil && output != nil {
 		addConsumedCapacity(p.cc, output.ConsumedCapacity)
 	}
 	return

--- a/update.go
+++ b/update.go
@@ -349,7 +349,7 @@ func (u *Update) run(ctx context.Context) (*dynamodb.UpdateItemOutput, error) {
 		output, err = u.table.db.client.UpdateItem(ctx, input)
 		return err
 	})
-	if u.cc != nil {
+	if u.cc != nil && output != nil {
 		addConsumedCapacity(u.cc, output.ConsumedCapacity)
 	}
 	return output, err


### PR DESCRIPTION
Hi, 

When testing we found that if the conditional check in a put is not met and we have consumed capacity set it will panic due to output being nil.

DynamoDB is working correctly where the output is nil if a conditional check failed https://github.com/aws/aws-sdk-go-v2/issues/2183.


I have added checks before working calling `addConsumedCapacity(u.cc, output.ConsumedCapacity)`.