### PR TITLE
Request count

### DIFF
--- a/batchget.go
+++ b/batchget.go
@@ -348,8 +348,8 @@ redo:
 		return false
 	}
 	if itr.bg.cc != nil {
-		for _, cc := range itr.output.ConsumedCapacity {
-			addConsumedCapacity(itr.bg.cc, &cc)
+		for i := range itr.output.ConsumedCapacity {
+			itr.bg.cc.add(&itr.output.ConsumedCapacity[i])
 		}
 	}
 

--- a/batchget.go
+++ b/batchget.go
@@ -341,6 +341,7 @@ redo:
 	itr.err = itr.bg.batch.table.db.retry(ctx, func() error {
 		var err error
 		itr.output, err = itr.bg.batch.table.db.client.BatchGetItem(ctx, itr.input)
+		itr.bg.cc.incRequests()
 		return err
 	})
 	if itr.err != nil {

--- a/batchwrite.go
+++ b/batchwrite.go
@@ -139,6 +139,7 @@ func (bw *BatchWrite) Run(ctx context.Context) (wrote int, err error) {
 			err := bw.batch.table.db.retry(ctx, func() error {
 				var err error
 				res, err = bw.batch.table.db.client.BatchWriteItem(ctx, req)
+				bw.cc.incRequests()
 				return err
 			})
 			if err != nil {

--- a/batchwrite.go
+++ b/batchwrite.go
@@ -146,8 +146,8 @@ func (bw *BatchWrite) Run(ctx context.Context) (wrote int, err error) {
 				return wrote, err
 			}
 			if bw.cc != nil {
-				for _, cc := range res.ConsumedCapacity {
-					addConsumedCapacity(bw.cc, &cc)
+				for i := range res.ConsumedCapacity {
+					bw.cc.add(&res.ConsumedCapacity[i])
 				}
 			}
 

--- a/delete.go
+++ b/delete.go
@@ -108,6 +108,7 @@ func (d *Delete) run(ctx context.Context) (*dynamodb.DeleteItemOutput, error) {
 	err := d.table.db.retry(ctx, func() error {
 		var err error
 		output, err = d.table.db.client.DeleteItem(ctx, input)
+		d.cc.incRequests()
 		return err
 	})
 	if d.cc != nil && output != nil {

--- a/delete.go
+++ b/delete.go
@@ -111,8 +111,8 @@ func (d *Delete) run(ctx context.Context) (*dynamodb.DeleteItemOutput, error) {
 		d.cc.incRequests()
 		return err
 	})
-	if d.cc != nil && output != nil {
-		addConsumedCapacity(d.cc, output.ConsumedCapacity)
+	if output != nil {
+		d.cc.add(output.ConsumedCapacity)
 	}
 	return output, err
 }

--- a/put.go
+++ b/put.go
@@ -81,6 +81,7 @@ func (p *Put) run(ctx context.Context) (output *dynamodb.PutItemOutput, err erro
 	req := p.input()
 	p.table.db.retry(ctx, func() error {
 		output, err = p.table.db.client.PutItem(ctx, req)
+		p.cc.incRequests()
 		return err
 	})
 	if p.cc != nil && output != nil {

--- a/put.go
+++ b/put.go
@@ -84,8 +84,8 @@ func (p *Put) run(ctx context.Context) (output *dynamodb.PutItemOutput, err erro
 		p.cc.incRequests()
 		return err
 	})
-	if p.cc != nil && output != nil {
-		addConsumedCapacity(p.cc, output.ConsumedCapacity)
+	if output != nil {
+		p.cc.add(output.ConsumedCapacity)
 	}
 	return
 }

--- a/query.go
+++ b/query.go
@@ -221,6 +221,7 @@ func (q *Query) One(ctx context.Context, out interface{}) error {
 		err := q.table.db.retry(ctx, func() error {
 			var err error
 			res, err = q.table.db.client.GetItem(ctx, req)
+			q.cc.incRequests()
 			if err != nil {
 				return err
 			}
@@ -246,6 +247,7 @@ func (q *Query) One(ctx context.Context, out interface{}) error {
 	err := q.table.db.retry(ctx, func() error {
 		var err error
 		res, err = q.table.db.client.Query(ctx, req)
+		q.cc.incRequests()
 		if err != nil {
 			return err
 		}
@@ -288,6 +290,7 @@ func (q *Query) Count(ctx context.Context) (int, error) {
 		err := q.table.db.retry(ctx, func() error {
 			var err error
 			res, err = q.table.db.client.Query(ctx, input)
+			q.cc.incRequests()
 			if err != nil {
 				return err
 			}
@@ -392,6 +395,7 @@ func (itr *queryIter) Next(ctx context.Context, out interface{}) bool {
 	itr.err = itr.query.table.db.retry(ctx, func() error {
 		var err error
 		itr.output, err = itr.query.table.db.client.Query(ctx, itr.input)
+		itr.query.cc.incRequests()
 		return err
 	})
 

--- a/query.go
+++ b/query.go
@@ -233,9 +233,7 @@ func (q *Query) One(ctx context.Context, out interface{}) error {
 		if err != nil {
 			return err
 		}
-		if q.cc != nil {
-			addConsumedCapacity(q.cc, res.ConsumedCapacity)
-		}
+		q.cc.add(res.ConsumedCapacity)
 
 		return unmarshalItem(res.Item, out)
 	}
@@ -266,9 +264,7 @@ func (q *Query) One(ctx context.Context, out interface{}) error {
 	if err != nil {
 		return err
 	}
-	if q.cc != nil {
-		addConsumedCapacity(q.cc, res.ConsumedCapacity)
-	}
+	q.cc.add(res.ConsumedCapacity)
 
 	return unmarshalItem(res.Items[0], out)
 }
@@ -304,9 +300,7 @@ func (q *Query) Count(ctx context.Context) (int, error) {
 		if err != nil {
 			return 0, err
 		}
-		if q.cc != nil {
-			addConsumedCapacity(q.cc, res.ConsumedCapacity)
-		}
+		q.cc.add(res.ConsumedCapacity)
 
 		q.startKey = res.LastEvaluatedKey
 		if res.LastEvaluatedKey == nil ||
@@ -402,9 +396,7 @@ func (itr *queryIter) Next(ctx context.Context, out interface{}) bool {
 	if itr.err != nil {
 		return false
 	}
-	if itr.query.cc != nil {
-		addConsumedCapacity(itr.query.cc, itr.output.ConsumedCapacity)
-	}
+	itr.query.cc.add(itr.output.ConsumedCapacity)
 	if len(itr.output.LastEvaluatedKey) > len(itr.exLEK) {
 		itr.exLEK = itr.output.LastEvaluatedKey
 	}

--- a/scan.go
+++ b/scan.go
@@ -264,10 +264,7 @@ func (s *Scan) Count(ctx context.Context) (int, error) {
 
 		count += int(out.Count)
 		scanned += out.ScannedCount
-
-		if s.cc != nil {
-			addConsumedCapacity(s.cc, out.ConsumedCapacity)
-		}
+		s.cc.add(out.ConsumedCapacity)
 
 		if out.LastEvaluatedKey == nil ||
 			(s.limit > 0 && count >= s.limit) ||
@@ -407,9 +404,7 @@ redo:
 	if itr.err != nil {
 		return false
 	}
-	if itr.scan.cc != nil {
-		addConsumedCapacity(itr.scan.cc, itr.output.ConsumedCapacity)
-	}
+	itr.scan.cc.add(itr.output.ConsumedCapacity)
 	if len(itr.output.LastEvaluatedKey) > len(itr.exLEK) {
 		itr.exLEK = itr.output.LastEvaluatedKey
 	}

--- a/scan.go
+++ b/scan.go
@@ -254,6 +254,7 @@ func (s *Scan) Count(ctx context.Context) (int, error) {
 		err := s.table.db.retry(ctx, func() error {
 			var err error
 			out, err = s.table.db.client.Scan(ctx, input)
+			s.cc.incRequests()
 			return err
 		})
 		if err != nil {
@@ -399,6 +400,7 @@ redo:
 	itr.err = itr.scan.table.db.retry(ctx, func() error {
 		var err error
 		itr.output, err = itr.scan.table.db.client.Scan(ctx, itr.input)
+		itr.scan.cc.incRequests()
 		return err
 	})
 

--- a/table.go
+++ b/table.go
@@ -207,6 +207,7 @@ type ConsumedCapacity struct {
 	// Write is the total number of write capacity units consumed during this operation.
 	// This seems to be only set for transactions.
 	Write float64
+
 	// GSI is a map of Global Secondary Index names to total consumed capacity units.
 	GSI map[string]float64
 	// GSIRead is a map of Global Secondary Index names to consumed read capacity units.
@@ -215,6 +216,7 @@ type ConsumedCapacity struct {
 	// GSIWrite is a map of Global Secondary Index names to consumed write capacity units.
 	// This seems to be only set for transactions.
 	GSIWrite map[string]float64
+
 	// LSI is a map of Local Secondary Index names to total consumed capacity units.
 	LSI map[string]float64
 	// LSIRead is a map of Local Secondary Index names to consumed read capacity units.
@@ -223,6 +225,7 @@ type ConsumedCapacity struct {
 	// LSIWrite is a map of Local Secondary Index names to consumed write capacity units.
 	// This seems to be only set for transactions.
 	LSIWrite map[string]float64
+
 	// Table is the amount of total throughput consumed by the table.
 	Table float64
 	// TableRead is the amount of read throughput consumed by the table.
@@ -233,6 +236,9 @@ type ConsumedCapacity struct {
 	TableWrite float64
 	// TableName is the name of the table affected by this operation.
 	TableName string
+
+	// Requests is the number of SDK requests made against DynamoDB's API.
+	Requests int
 }
 
 func addConsumedCapacity(cc *ConsumedCapacity, raw *types.ConsumedCapacity) {
@@ -302,6 +308,13 @@ func addConsumedCapacity(cc *ConsumedCapacity, raw *types.ConsumedCapacity) {
 	}
 }
 
+func (cc *ConsumedCapacity) incRequests() {
+	if cc == nil {
+		return
+	}
+	cc.Requests++
+}
+
 func mergeConsumedCapacity(dst, src *ConsumedCapacity) {
 	if dst == nil || src == nil {
 		return
@@ -363,4 +376,5 @@ func mergeConsumedCapacity(dst, src *ConsumedCapacity) {
 	if dst.TableName == "" && src.TableName != "" {
 		dst.TableName = src.TableName
 	}
+	dst.Requests += src.Requests
 }

--- a/table.go
+++ b/table.go
@@ -241,7 +241,7 @@ type ConsumedCapacity struct {
 	Requests int
 }
 
-func addConsumedCapacity(cc *ConsumedCapacity, raw *types.ConsumedCapacity) {
+func (cc *ConsumedCapacity) add(raw *types.ConsumedCapacity) {
 	if cc == nil || raw == nil {
 		return
 	}

--- a/table_test.go
+++ b/table_test.go
@@ -175,6 +175,15 @@ func TestAddConsumedCapacity(t *testing.T) {
 	if !reflect.DeepEqual(cc, expected) {
 		t.Error("bad ConsumedCapacity:", cc, "≠", expected)
 	}
+
+	t.Run("request count", func(t *testing.T) {
+		const expectedReqs = 2
+		cc.incRequests()
+		cc.incRequests()
+		if cc.Requests != expectedReqs {
+			t.Error("bad Requests count:", cc.Requests, "≠", expectedReqs)
+		}
+	})
 }
 
 func normalizeDesc(desc *Description) {

--- a/table_test.go
+++ b/table_test.go
@@ -170,7 +170,7 @@ func TestAddConsumedCapacity(t *testing.T) {
 	}
 
 	var cc = new(ConsumedCapacity)
-	addConsumedCapacity(cc, raw)
+	cc.add(raw)
 
 	if !reflect.DeepEqual(cc, expected) {
 		t.Error("bad ConsumedCapacity:", cc, "≠", expected)

--- a/tx.go
+++ b/tx.go
@@ -72,8 +72,8 @@ func (tx *GetTx) Run(ctx context.Context) error {
 		resp, err = tx.db.client.TransactGetItems(ctx, input)
 		tx.cc.incRequests()
 		if tx.cc != nil && resp != nil {
-			for _, cc := range resp.ConsumedCapacity {
-				addConsumedCapacity(tx.cc, &cc)
+			for i := range resp.ConsumedCapacity {
+				tx.cc.add(&resp.ConsumedCapacity[i])
 			}
 		}
 		return err
@@ -113,8 +113,8 @@ func (tx *GetTx) All(ctx context.Context, out interface{}) error {
 		resp, err = tx.db.client.TransactGetItems(ctx, input)
 		tx.cc.incRequests()
 		if tx.cc != nil && resp != nil {
-			for _, cc := range resp.ConsumedCapacity {
-				addConsumedCapacity(tx.cc, &cc)
+			for i := range resp.ConsumedCapacity {
+				tx.cc.add(&resp.ConsumedCapacity[i])
 			}
 		}
 		return err
@@ -259,9 +259,9 @@ func (tx *WriteTx) Run(ctx context.Context) error {
 	err = tx.db.retry(ctx, func() error {
 		out, err := tx.db.client.TransactWriteItems(ctx, input)
 		tx.cc.incRequests()
-		if tx.cc != nil && out != nil {
-			for _, cc := range out.ConsumedCapacity {
-				addConsumedCapacity(tx.cc, &cc)
+		if out != nil {
+			for i := range out.ConsumedCapacity {
+				tx.cc.add(&out.ConsumedCapacity[i])
 			}
 		}
 		return err

--- a/tx.go
+++ b/tx.go
@@ -70,6 +70,7 @@ func (tx *GetTx) Run(ctx context.Context) error {
 	err = tx.db.retry(ctx, func() error {
 		var err error
 		resp, err = tx.db.client.TransactGetItems(ctx, input)
+		tx.cc.incRequests()
 		if tx.cc != nil && resp != nil {
 			for _, cc := range resp.ConsumedCapacity {
 				addConsumedCapacity(tx.cc, &cc)
@@ -110,6 +111,7 @@ func (tx *GetTx) All(ctx context.Context, out interface{}) error {
 	err = tx.db.retry(ctx, func() error {
 		var err error
 		resp, err = tx.db.client.TransactGetItems(ctx, input)
+		tx.cc.incRequests()
 		if tx.cc != nil && resp != nil {
 			for _, cc := range resp.ConsumedCapacity {
 				addConsumedCapacity(tx.cc, &cc)
@@ -256,6 +258,7 @@ func (tx *WriteTx) Run(ctx context.Context) error {
 	}
 	err = tx.db.retry(ctx, func() error {
 		out, err := tx.db.client.TransactWriteItems(ctx, input)
+		tx.cc.incRequests()
 		if tx.cc != nil && out != nil {
 			for _, cc := range out.ConsumedCapacity {
 				addConsumedCapacity(tx.cc, &cc)

--- a/update.go
+++ b/update.go
@@ -347,6 +347,7 @@ func (u *Update) run(ctx context.Context) (*dynamodb.UpdateItemOutput, error) {
 	err := u.table.db.retry(ctx, func() error {
 		var err error
 		output, err = u.table.db.client.UpdateItem(ctx, input)
+		u.cc.incRequests()
 		return err
 	})
 	if u.cc != nil && output != nil {

--- a/update.go
+++ b/update.go
@@ -350,8 +350,8 @@ func (u *Update) run(ctx context.Context) (*dynamodb.UpdateItemOutput, error) {
 		u.cc.incRequests()
 		return err
 	})
-	if u.cc != nil && output != nil {
-		addConsumedCapacity(u.cc, output.ConsumedCapacity)
+	if output != nil {
+		u.cc.add(output.ConsumedCapacity)
 	}
 	return output, err
 }


### PR DESCRIPTION
Adds a new field to `ConsumedCapacity` called `Requests`. It increments each time an SDK call is made.
Ideally we probably want to hook the AWS SDK middleware stuff to catch their retries but I wanted to get a simple 90% solution out there first.

See: #238