### PR TITLE
Fix Query.One + Filter behavior (#248)

### DIFF
--- a/query.go
+++ b/query.go
@@ -208,6 +208,9 @@ func (q *Query) ConsumedCapacity(cc *ConsumedCapacity) *Query {
 
 // One executes this query and retrieves a single result,
 // unmarshaling the result to out.
+// This uses the DynamoDB GetItem API when possible, otherwise Query.
+// If the query returns more than one result, [ErrTooMany] may be returned. This is intended as a diagnostic for query mistakes.
+// To avoid [ErrTooMany], set the [Query.Limit] to 1.
 func (q *Query) One(ctx context.Context, out interface{}) error {
 	if q.err != nil {
 		return q.err

--- a/query.go
+++ b/query.go
@@ -240,7 +240,8 @@ func (q *Query) One(ctx context.Context, out interface{}) error {
 
 	// If not, try a Query.
 	iter := q.Iter().(*queryIter)
-	ok := iter.Next(ctx, out)
+	var item Item
+	ok := iter.Next(ctx, &item)
 	if err := iter.Err(); err != nil {
 		return err
 	}
@@ -251,7 +252,7 @@ func (q *Query) One(ctx context.Context, out interface{}) error {
 	if iter.hasMore() {
 		return ErrTooMany
 	}
-	return nil
+	return unmarshalItem(item, out)
 }
 
 // Count executes this request, returning the number of results.


### PR DESCRIPTION
See: #248

When `One` can't use the GetItem API, it triggers a Query. Previously these would only check one results page, which interacted poorly with `Filter`, potentially dropping results in large but empty datasets. Now, we iterate through pages until we find a result. `ErrTooMany` is emitted on a best-effort basis.

To preserve the old behavior, use `RequestLimit(1)` or `SearchFilter(N)`.

@dharkness please take a look and see if this helps your use case. This is the simplest way I could think to implement it. I think the root cause was simply that One was written without Filter in mind, much of its code untouched for 9 years.