### PR TITLE
SetIfNotNil

### DIFF
--- a/update.go
+++ b/update.go
@@ -132,6 +132,26 @@ func (u *Update) SetIfNotExists(path string, value interface{}) *Update {
 	return u
 }
 
+// SetIfNotNil changes path to the given value only if the value and marshalled value are not nil.
+func (u *Update) SetIfNotNil(path string, value interface{}) *Update {
+	if value == nil {
+		return u
+	}
+
+	v, err := marshal(value, flagNone)
+	if v == nil && err == nil {
+		return u
+	}
+	u.setError(err)
+
+	path, err = u.escape(path)
+	u.setError(err)
+	expr, err := u.subExpr("🝕 = ?", path, v)
+	u.setError(err)
+	u.set = append(u.set, expr)
+	return u
+}
+
 // SetExpr performs a custom set expression, substituting the args into expr as in filter expressions.
 // See: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html#DDB-UpdateItem-request-UpdateExpression
 //

--- a/update_test.go
+++ b/update_test.go
@@ -80,6 +80,7 @@ func TestUpdate(t *testing.T) {
 	err = table.Update("UserID", item.UserID).
 		Range("Time", item.Time).
 		Set("Msg", "changed").
+		SetIfNotNil("Msg", nil).
 		SetExpr("Meta.$ = ?", "foo", "baz").
 		SetExpr("$", setLit).
 		Add("Count", 1).


### PR DESCRIPTION
Adds support, as described in #250, for `SetIfNotNil` to allow updating of paths only if the value is not nil and preserve existing values when the new value is nil. 

Should take care of both cases when `value = nil` as well as `marshalled value = nil`. 

Added a small entry in the test cases to try to override `Msg` which should not do anything in this case. For custom structs another test might be needed. 